### PR TITLE
Add "Chapel Module Index" page with all modules listed.

### DIFF
--- a/doc-test/foo.bar.rst
+++ b/doc-test/foo.bar.rst
@@ -1,0 +1,18 @@
+.. default-domain:: chpl
+
+.. module:: Foo.Bar
+
+Module: Foo.Bar
+===============
+
+asdf
+
+a
+a
+sdf
+sad
+
+
+.. function:: myProc()
+
+    This is defined in Foo.Bar, as Foo.Bar.myProc()!

--- a/doc-test/foo.rst
+++ b/doc-test/foo.rst
@@ -1,0 +1,18 @@
+.. default-domain:: chpl
+
+.. module:: Foo
+
+Module: Foo
+===========
+
+foo documenation is very important!
+
+Foo submodules:
+
+.. toctree::
+    foo.bar
+
+.. function:: myProc()
+
+    This is defined in Foo module!
+

--- a/doc-test/index.rst
+++ b/doc-test/index.rst
@@ -19,6 +19,7 @@ Module 'Foo'
    BitOps
    Vector
    Containers
+   foo
 
 .. default-domain:: chpl
 
@@ -47,6 +48,10 @@ Module 'Foo'
 .. type:: U
 
     I can haz *U*?
+
+**Does it work???**
+
+* :chpl:ref:`modindex`
 
 Do these XRefs work?
 --------------------
@@ -98,4 +103,3 @@ Indices and tables
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
-

--- a/doc-test/index.rst
+++ b/doc-test/index.rst
@@ -21,7 +21,13 @@ Module 'Foo'
    Containers
    foo
 
+**Does it work???**
+
+* :chpl:chplref:`chplmodindex`
+
 .. default-domain:: chpl
+
+* :chplref:`Stuff... <chplmodindex>`
 
 .. data:: const constTest
 
@@ -48,10 +54,6 @@ Module 'Foo'
 .. type:: U
 
     I can haz *U*?
-
-**Does it work???**
-
-* :chpl:ref:`modindex`
 
 Do these XRefs work?
 --------------------

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -326,6 +326,8 @@ a matching identifier is found:
 
         For example, see all modules in the :chplref:`chplmodindex`.
 
+    .. versionadded:: 0.0.3
+
     .. warning::
 
         ``chplmodindex`` is a special name, like ``modindex``, ``genindex``,

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -314,6 +314,24 @@ a matching identifier is found:
 
     Reference a data attribute (const, var, param, generic type) of an object.
 
+.. role:: chpl:chplref
+
+    Special Chapel reference, which acts just like ``:ref:``. Used to
+    cross-reference the "Chapel Module Index". For example::
+
+        * :chpl:chplref:`chplmodindex`
+        * :chpl:chplref:`The module index <chplmodindex>`
+
+        Or, with the default-domain or primary_domain set to chpl:
+
+        For example, see all modules in the :chplref:`chplmodindex`.
+
+    .. warning::
+
+        ``chplmodindex`` is a special name, like ``modindex``, ``genindex``,
+        and ``search``. Do not create documents named ``chplmodindex``, as it
+        will cause problems.
+
 .. _chapel-xref-content:
 
 Cross-reference Contents
@@ -376,3 +394,21 @@ Note that you can combine the ``~`` and ``.``
 prefixes. ``:chpl:meth:`~.channel.read``` will reference the
 ``IO.channel.read()`` method, but the visible link caption will only be
 ``read``.
+
+Sphinx Configuration
+--------------------
+
+This section lists additional configuration values that are added to the "build
+configuration file", i.e. ``conf.py``, when using the Chapel domain.
+
+.. This is py:data because that works and looks ok. It's not really python
+   module data.
+.. py:data:: chapeldomain_modindex_common_prefix
+
+    A list of prefixes that are ignored for sorting the Chapel module index
+    (e.g. if this is set to ``['foo.']``, then ``foo.bar`` module is shown
+    under ``B``, instead of ``F``). This is useful when documenting a project
+    that consists of a single package. Currently only works for the HTML
+    builder. Default is ``[]``.
+
+    .. versionadded:: 0.0.3

--- a/sphinxcontrib/chapeldomain.py
+++ b/sphinxcontrib/chapeldomain.py
@@ -30,7 +30,7 @@ from sphinx.util.docfields import Field, TypedField
 from sphinx.util.nodes import make_refnode
 
 
-VERSION = '0.0.2'
+VERSION = '0.0.3'
 
 
 # regex for parsing proc, iter, class, record, etc.

--- a/sphinxcontrib/chapeldomain.py
+++ b/sphinxcontrib/chapeldomain.py
@@ -728,12 +728,12 @@ class ChapelDomain(Domain):
     }
 
     initial_data = {
-        'objects': {},  # fullname -> docname, objtype
-        'modules': {},  # modname -> docname, synopsis, platform, deprecated
-        'labels': {     # labelname -> docname, labelid, sectionname
+        'objects': {},   # fullname -> docname, objtype
+        'modules': {},   # modname -> docname, synopsis, platform, deprecated
+        'labels': {      # labelname -> docname, labelid, sectionname
             'chplmodindex': ('chpl-modindex', '', l_('Chapel Module Index')),
         },
-        'anonlabels': { # labelname -> docname, labelid
+        'anonlabels': {  # labelname -> docname, labelid
             'chplmodindex': ('chpl-modindex', ''),
         },
     }
@@ -744,16 +744,16 @@ class ChapelDomain(Domain):
 
     def clear_doc(self, docname):
         """Remove the data associated with this instance of the domain."""
-        for fullname, (fn, _) in self.data['objects'].items():
+        for fullname, (fn, x) in self.data['objects'].items():
             if fn == docname:
                 del self.data['objects'][fullname]
-        for modname, (fn, _, _, _) in self.data['modules'].items():
+        for modname, (fn, x, x, x) in self.data['modules'].items():
             if fn == docname:
                 del self.data['modules'][modname]
-        for labelname, (fn, _, _) in self.data['labels'].items():
+        for labelname, (fn, x, x) in self.data['labels'].items():
             if fn == docname:
                 del self.data['labels'][labelname]
-        for anonlabelname, (fn, _) in self.data['anonlabels'].items():
+        for anonlabelname, (fn, x) in self.data['anonlabels'].items():
             if fn == docname:
                 del self.data['anonlabels'][anonlabelname]
 
@@ -827,17 +827,20 @@ class ChapelDomain(Domain):
             if node['refexplicit']:
                 # Reference to anonymous label. The reference uses the supplied
                 # link caption.
-                docname, labelid = self.data['anonlabels'].get(target, ('', ''))
+                docname, labelid = self.data['anonlabels'].get(
+                    target, ('', ''))
                 sectname = node.astext()
             else:
                 # Reference to named label. The final node will contain the
                 # section name after the label.
-                docname, labelid, sectname = self.data['labels'].get(target, ('', '', ''))
+                docname, labelid, sectname = self.data['labels'].get(
+                    target, ('', '', ''))
 
             if not docname:
                 return None
 
-            return self._make_refnode(fromdocname, builder, docname, labelid, sectname, contnode)
+            return self._make_refnode(
+                fromdocname, builder, docname, labelid, sectname, contnode)
 
         modname = node.get('chpl:module')
         clsname = node.get('chpl:class')
@@ -886,7 +889,8 @@ class ChapelDomain(Domain):
 
         return results
 
-    def _make_refnode(self, fromdocname, builder, docname, labelid, sectname, contnode, **kwargs):
+    def _make_refnode(self, fromdocname, builder, docname, labelid, sectname,
+                      contnode, **kwargs):
         """Return reference node for something like ``:chpl:chplref:``."""
         nodeclass = kwargs.pop('nodeclass', nodes.reference)
         newnode = nodeclass('', '', internal=True, **kwargs)


### PR DESCRIPTION
Add new ChapelModuleIndex that creates a list of all chapel modules
similar to the python module index. It sorts them alphabetically and groups
them by first letter. Submodules are supported and get folded under the original
top level module.

To cross-reference the new Chapel Module Index, support a special role,
`:chpl:chplref:`. It can be used like:

``` rst
* :chpl:chplref:`chplmodindex`
* :chpl:chplref:`See my modules <chplmodindex>`

.. And it works with the default-domain (or primary_domain) settings.

.. default-domain:: chpl

See the :chplref:`chplmodindex` for details.
```
