### PR TITLE
Support sync symbol names with $.

### DIFF
--- a/doc-test/classes.rst
+++ b/doc-test/classes.rst
@@ -31,6 +31,10 @@ Chapel classes
         One dimensional array that stores elements of vector. See also
         :chpl:attr:`ChplVector.dom`.
 
+    .. attribute:: var lock$: sync bool
+
+        Instance lock that ensures certain operations are serialized.
+
     .. method:: ChplVector(type eltType, cap=4, offset=0)
 
         Initialize new generic ChplVector of type eltType. See

--- a/sphinxcontrib/chapeldomain.py
+++ b/sphinxcontrib/chapeldomain.py
@@ -38,8 +38,8 @@ chpl_sig_pattern = re.compile(
     r"""^ ((?:\w+\s+)*                   # optional: prefixes
            (?:proc|iter|class|record)\s+ #   must end with keyword
           )?
-          ([\w.]*\.)?                    # class name(s)
-          ([\w\+\-/\*]+)  \s*            # function or method name
+          ([\w$.]*\.)?                   # class name(s)
+          ([\w\+\-/\*$]+)  \s*           # function or method name
           (?:\((.*?)\))?                 # optional: arguments
           (?:\s* [:\s] \s* (.*))?        #   or return type or ref intent
           $""", re.VERBOSE)
@@ -47,8 +47,8 @@ chpl_sig_pattern = re.compile(
 # regex for parsing attribute and data directives.
 chpl_attr_sig_pattern = re.compile(
     r"""^ ((?:\w+\s+)*)?      # optional: prefixes
-          ([\w.]*\.)?         # class name(s)
-          (\w+) \s*           # const, var, param, etc name
+          ([\w$.]*\.)?        # class name(s)
+          ([\w$]+) \s*        # const, var, param, etc name
           (?:\s* : \s* (.*))? # optional: type
           $""", re.VERBOSE)
 

--- a/sphinxcontrib/chapeldomain.py
+++ b/sphinxcontrib/chapeldomain.py
@@ -30,7 +30,7 @@ from sphinx.util.docfields import Field, TypedField
 from sphinx.util.nodes import make_refnode
 
 
-VERSION = '0.0.3'
+VERSION = '0.0.4'
 
 
 # regex for parsing proc, iter, class, record, etc.

--- a/test/test_chapeldomain.py
+++ b/test/test_chapeldomain.py
@@ -485,6 +485,8 @@ class SigPatternTests(PatternTestCase):
             ('these() ref', None, None, 'these', '', 'ref'),
             ('size', None, None, 'size', None, None),
             ('proc Util.toVector(type eltType, cap=4, offset=0): Containers.Vector', 'proc ', 'Util.', 'toVector', 'type eltType, cap=4, offset=0', 'Containers.Vector'),
+            ('proc MyClass$.lock$(combo$): sync bool', 'proc ', 'MyClass$.', 'lock$', 'combo$', 'sync bool'),
+            ('proc MyClass$.lock$(combo$): sync myBool$', 'proc ', 'MyClass$.', 'lock$', 'combo$', 'sync myBool$'),
         ]
         for sig, prefix, class_name, name, arglist, retann in test_cases:
             self.check_sig(sig, prefix, class_name, name, arglist, retann)
@@ -574,6 +576,9 @@ class AttrSigPatternTests(PatternTestCase):
             ('var X.n: MyMod.MyClass', 'var ', 'X.', 'n', 'MyMod.MyClass'),
             ('config param debugAdvancedIters:bool', 'config param ', None, 'debugAdvancedIters', 'bool'),
             ('config param MyMod.DEBUG: bool', 'config param ', 'MyMod.', 'DEBUG', 'bool'),
+            ('var RandomStreamPrivate_lock$: _syncvar(bool)', 'var ', None, 'RandomStreamPrivate_lock$', '_syncvar(bool)'),
+            ('var RandomStreamPrivate_lock$: sync bool', 'var ', None, 'RandomStreamPrivate_lock$', 'sync bool'),
+            ('const RS$.lock$: sync MyMod$.MyClass$.bool', 'const ', 'RS$.', 'lock$', 'sync MyMod$.MyClass$.bool'),
         ]
         for sig, prefix, class_name, attr, type_name in test_cases:
             self.check_sig(sig, prefix, class_name, attr, type_name)


### PR DESCRIPTION
Update signature parsers to correctly identify symbols with `$` in their
names (e.g. sync vars).
