### PR TITLE
Use arguments instead of parameters in docs and code.

### DIFF
--- a/doc-test/Vector.rst
+++ b/doc-test/Vector.rst
@@ -14,7 +14,7 @@ Module: VectorFake
     .. FIXME: should ~ links display as hole value or just leaf value??? (thomasvandoren, 2015-01-22)
 
     `FIXME: <only copyright comment in file>` blah blah
-    :chpl:func:`~BitOps.clz`... :chpl:attr:`~MyModule.ChplVector.elements`
+    :chpl:proc:`~BitOps.clz`... :chpl:attr:`~MyModule.ChplVector.elements`
     blah blah :chpl:meth:`~MyModule.ChplBigNum.fromInt`. See :chpl:mod:`BitOps`.
 
     .. attribute:: type eltType

--- a/doc-test/functions.rst
+++ b/doc-test/functions.rst
@@ -10,14 +10,14 @@ Chapel Functions
 .. function:: noParens
 
     A function without parenthesis. What is the world coming to?
-    :chpl:func:`sendIt`. See also :chpl:func:`noParensRet`.
+    :chpl:proc:`sendIt`. See also :chpl:proc:`noParensRet`.
 
     :returns: something really, really interesting... jk
 
 .. function:: noParensRet: int
 
     A function without parenthesis with a return type. See also
-    :chpl:func:`noParens`...
+    :chpl:proc:`noParens`...
 
     :rtype: int
     :returns: integer value with invoking function (e.g. just call
@@ -25,19 +25,19 @@ Chapel Functions
 
 .. function:: send()
 
-    Send something... blah blah :chpl:func:`messageId`. blah blah
-    :chpl:func:`noParens`
+    Send something... blah blah :chpl:proc:`messageId`. blah blah
+    :chpl:proc:`noParens`
 
 .. function:: sendIt()
 
-    Send it. See :chpl:func:`send` and :chpl:func:`sendItAgain`.
+    Send it. See :chpl:proc:`send` and :chpl:proc:`sendItAgain`.
 
     :returns: it
     :rtype: Message
 
 .. function:: sendItAgain(): Message
 
-    Send it. See :chpl:func:`sendMessage`...
+    Send it. See :chpl:proc:`sendMessage`...
 
     :returns: it
     :rtype: Message
@@ -52,21 +52,21 @@ Chapel Functions
 
 .. function:: takeAType(type someType)
 
-    Takes a generic type of some sort... see also :chpl:func:`returnRef`.
+    Takes a generic type of some sort... see also :chpl:proc:`returnRef`.
 
     :arg type someType: the generic type
     :returns: new instance of someType
 
 .. function:: returnRef() ref
 
-    Returns reference to some value. See also :chpl:func:`takeAType`.
+    Returns reference to some value. See also :chpl:proc:`takeAType`.
 
     :returns: reference to known value
     :rtype: MyType
 
 .. function:: sendMessage(sender, recipient, message_body, [priority=1])
 
-    Send a message to a recipient. ... :chpl:func:`sendMessageFullyTyped` ...
+    Send a message to a recipient. ... :chpl:proc:`sendMessageFullyTyped` ...
 
     :arg string sender: The person sending the message
     :arg string recipient: The recipient of the message
@@ -78,7 +78,7 @@ Chapel Functions
 
 .. function:: sendMessageFullyTyped(sender: string, recipient: string, message_body: string, [priority: int=1]): int
 
-    Send a message to a recipient... see also :chpl:func:`sendMessage`
+    Send a message to a recipient... see also :chpl:proc:`sendMessage`
 
     :arg string sender: The person sending the message
     :arg string recipient: The recipient of the message
@@ -91,8 +91,8 @@ Chapel Functions
 .. iterfunction:: fib(n)
 
     Iterate through first ``n`` Fibonacci numbers. Can xref me with
-    ``:chpl:iter:``? :chpl:iter:`fib` ? How about ``:chpl:func:``?
-    :chpl:func:`fib` ? And ``:chpl:proc:``? :chpl:proc:`fib` ?
+    ``:chpl:iter:``? :chpl:iter:`fib` ? How about ``:chpl:proc:``?
+    :chpl:proc:`fib` ? And ``:chpl:proc:``? :chpl:proc:`fib` ?
 
     :arg int n: Number of Fibonacci numbers to return.
     :ytype: int

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -51,7 +51,7 @@ The following directives are provided for module and class contents.
 .. directive:: .. chpl:function:: signature
 
     Describes a module-level function. The signature should include the
-    parameters as given in the Chapel definition. See :ref:`signatures` for
+    arguments as given in the Chapel definition. See :ref:`signatures` for
     details.
 
     For example::
@@ -62,9 +62,8 @@ The following directives are provided for module and class contents.
     iterators, see :rst:dir:`chpl:method` and :rst:dir:`chpl:itermethod`
     respectively.
 
-    The description normally includes information about the parameters
-    required, how they are used, side effects, return type, and return
-    description.
+    The description normally includes information about the arguments required,
+    how they are used, side effects, return type, and return description.
 
     This information can (in any ``chpl`` directive) optionally be given in a
     structured form, see :ref:`info-field-lists`.
@@ -120,7 +119,7 @@ For example, this would document a module with a ``proc`` and an ``iter``::
 .. directive:: .. chpl:class:: signature
 
     Describe a class. The signature can optionally include parentheses with
-    parameters which will be shown as the constructor arguments. See also
+    arguments which will be shown as the constructor arguments. See also
     :ref:`signatures`.
 
     Methods and attributes belonging to the class should be placed in this

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -94,7 +94,7 @@ For example, this would document a module with a ``proc`` and an ``iter``::
         Yield fibonacci numbers infinitely. It is up to caller to break
         iteration.
 
-        Often called with :chpl:func:`zip` to track current number. For
+        Often called with :chpl:proc:`zip` to track current number. For
         example:
 
         .. code-block:: chapel
@@ -283,11 +283,18 @@ a matching identifier is found:
     Reference a module; a dotted name may be used. See :ref:`Cross-reference
     Contents <chapel-xref-content>` for details on dotted and non-dotted names.
 
-.. role:: chpl:func
+.. role:: chpl:proc
           chpl:iter
 
-    Reference a Chapel function or iterator; dotted names may be used. The role
-    text needs not include trailing parentheses to enhance readability.
+    Reference a Chapel function or iterator. The role text needs not include
+    trailing parentheses to enhance readability.
+
+    These can also be used to reference a method or iterator on an object
+    (class or record instance). The role text can include the type name and the
+    method, in those cases. If it occurs within the description of a type, the
+    type name can be omitted.
+
+    Dotted names may be used for any form.
 
 .. role:: chpl:data
           chpl:const
@@ -301,14 +308,6 @@ a matching identifier is found:
           chpl:record
 
     Reference a class or record; a dotted name may be used.
-
-.. role:: chpl:meth
-          chpl:iter
-
-    Reference a method or iterator of an object (class or record). The role
-    text can include the type name and the method name. If it occurs within the
-    description of a type, the type name can be omitted. A dotted name may be
-    used.
 
 .. role:: chpl:attr
 
@@ -340,17 +339,17 @@ Cross-reference Contents
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 The name enclosed in this markup can include a module name and/or a class or
-record name. For example, ``:chpl:func:`writeln``` could refer to a function
+record name. For example, ``:chpl:proc:`writeln``` could refer to a function
 named ``writeln`` in the current module, or the built-in function of that
-name. In contrast, ``:chpl:func:`Foo.writeln``` clearly refers to the
+name. In contrast, ``:chpl:proc:`Foo.writeln``` clearly refers to the
 ``writeln`` function in the ``Foo`` module.
 
 Normally, names in these roles are searched first without any further
 qualification, then with the current module name prepended, then with the
 current module and class name (if any) prepended. If you prefix the name with a
 dot, this order is reserved. For example, in the documentation of the ``IO``
-module, ``:chpl:func:`writeln``` always refers to the built-in function, while
-``:chpl:func:`.writeln``` refers to ``IO.writeln``.
+module, ``:chpl:proc:`writeln``` always refers to the built-in function, while
+``:chpl:proc:`.writeln``` refers to ``IO.writeln``.
 
 For example, here is a description with both a non-dotted and a dotted
 cross-reference::
@@ -362,8 +361,8 @@ cross-reference::
         .. method:: read()
 
             Description...
-            example 1 --> :chpl:func:`writeln`
-            example 2 --> :chpl:func:`.writeln`
+            example 1 --> :chpl:proc:`writeln`
+            example 2 --> :chpl:proc:`.writeln`
 
 Example 1 will search for ``writeln`` cross-reference in this order:
 

--- a/sphinxcontrib/chapeldomain.py
+++ b/sphinxcontrib/chapeldomain.py
@@ -30,7 +30,7 @@ from sphinx.util.docfields import Field, TypedField
 from sphinx.util.nodes import make_refnode
 
 
-VERSION = '0.0.4'
+VERSION = '0.0.5'
 
 
 # regex for parsing proc, iter, class, record, etc.

--- a/sphinxcontrib/chapeldomain.py
+++ b/sphinxcontrib/chapeldomain.py
@@ -76,9 +76,15 @@ class ChapelObject(ObjectDescription):
     }
 
     doc_field_types = [
-        TypedField('parameter', label=l_('Parameters'),
+        TypedField('parameter', label=l_('Arguments'),
                    names=('param', 'parameter', 'arg', 'argument'),
-                   typerolename='obj', typenames=('paramtype', 'type'),
+
+                   # FIXME: Use role name here that exists and is general
+                   #        enough to reference anything... Maybe something
+                   #        like 'class'? (thomasvandoren, 2015-02-04)
+                   typerolename='obj',
+
+                   typenames=('paramtype', 'type'),
                    can_collapse=True),
         Field('returnvalue', label=l_('Returns'), has_arg=False,
               names=('returns', 'return')),


### PR DESCRIPTION
In chapel, parameters often describe compile time constants, while "arguments"
better describe the arguments to a function, iterators, or method.

Update arguments field name to be "Arguments" instead of "Parameters".

In the docs, use `:chpl:proc:` instead of `:chpl:func:` or `:chpl:meth:`.
