### PR TITLE
Update const, var, param, etc type parsing to include colon and space, like other sigs.

### DIFF
--- a/sphinxcontrib/chapeldomain.py
+++ b/sphinxcontrib/chapeldomain.py
@@ -30,7 +30,7 @@ from sphinx.util.docfields import Field, TypedField
 from sphinx.util.nodes import make_refnode
 
 
-VERSION = '0.0.6'
+VERSION = '0.0.7'
 
 
 # regex for parsing proc, iter, class, record, etc.

--- a/sphinxcontrib/chapeldomain.py
+++ b/sphinxcontrib/chapeldomain.py
@@ -50,8 +50,8 @@ chpl_sig_pattern = re.compile(
 chpl_attr_sig_pattern = re.compile(
     r"""^ ((?:\w+\s+)*)?          # optional: prefixes
           ([\w$.]*\.)?            # class name(s)
-          ([\w$]+) \s*            # const, var, param, etc name
-          (?:\s* : \s* ([^:]+))?  # optional: type
+          ([\w$]+)                # const, var, param, etc name
+          (\s* : \s* [^:]+)?      # optional: type
           $""", re.VERBOSE)
 
 

--- a/test/test_chapeldomain.py
+++ b/test/test_chapeldomain.py
@@ -565,12 +565,13 @@ class AttrSigPatternTests(PatternTestCase):
     def test_with_types(self):
         """Verify types parse correctly."""
         test_cases = [
-            ('foo: int', 'foo', 'int'),
-            ('bar: real', 'bar', 'real'),
-            ('baz: int(32)', 'baz', 'int(32)'),
-            ('D: domain(9)', 'D', 'domain(9)'),
-            ('A: [{1..n}] BigNum', 'A', '[{1..n}] BigNum'),
-            ('x: MyModule.MyClass', 'x', 'MyModule.MyClass'),
+            ('foo: int', 'foo', ': int'),
+            ('bar: real', 'bar', ': real'),
+            ('baz: int(32)', 'baz', ': int(32)'),
+            ('D: domain(9)', 'D', ': domain(9)'),
+            ('A: [{1..n}] BigNum', 'A', ': [{1..n}] BigNum'),
+            ('x: MyModule.MyClass', 'x', ': MyModule.MyClass'),
+            ('x  :  sync real', 'x', '  :  sync real'),
         ]
         for sig, attr, type_name in test_cases:
             self.check_sig(sig, '', None, attr, type_name)
@@ -578,13 +579,13 @@ class AttrSigPatternTests(PatternTestCase):
     def test_with_all(self):
         """Verify full specified signatures parse correctly."""
         test_cases = [
-            ('config const MyModule.MyClass.n: int', 'config const ', 'MyModule.MyClass.', 'n', 'int'),
-            ('var X.n: MyMod.MyClass', 'var ', 'X.', 'n', 'MyMod.MyClass'),
-            ('config param debugAdvancedIters:bool', 'config param ', None, 'debugAdvancedIters', 'bool'),
-            ('config param MyMod.DEBUG: bool', 'config param ', 'MyMod.', 'DEBUG', 'bool'),
-            ('var RandomStreamPrivate_lock$: _syncvar(bool)', 'var ', None, 'RandomStreamPrivate_lock$', '_syncvar(bool)'),
-            ('var RandomStreamPrivate_lock$: sync bool', 'var ', None, 'RandomStreamPrivate_lock$', 'sync bool'),
-            ('const RS$.lock$: sync MyMod$.MyClass$.bool', 'const ', 'RS$.', 'lock$', 'sync MyMod$.MyClass$.bool'),
+            ('config const MyModule.MyClass.n: int', 'config const ', 'MyModule.MyClass.', 'n', ': int'),
+            ('var X.n: MyMod.MyClass', 'var ', 'X.', 'n', ': MyMod.MyClass'),
+            ('config param debugAdvancedIters:bool', 'config param ', None, 'debugAdvancedIters', ':bool'),
+            ('config param MyMod.DEBUG: bool', 'config param ', 'MyMod.', 'DEBUG', ': bool'),
+            ('var RandomStreamPrivate_lock$: _syncvar(bool)', 'var ', None, 'RandomStreamPrivate_lock$', ': _syncvar(bool)'),
+            ('var RandomStreamPrivate_lock$: sync bool', 'var ', None, 'RandomStreamPrivate_lock$', ': sync bool'),
+            ('const RS$.lock$: sync MyMod$.MyClass$.bool', 'const ', 'RS$.', 'lock$', ': sync MyMod$.MyClass$.bool'),
         ]
         for sig, prefix, class_name, attr, type_name in test_cases:
             self.check_sig(sig, prefix, class_name, attr, type_name)


### PR DESCRIPTION
This complements PR #13, which was a similar change for regular, non-attr-like
signatures.
