### PR TITLE
Update field pattern to recognize type aliases.

### DIFF
--- a/sphinxcontrib/chapeldomain.py
+++ b/sphinxcontrib/chapeldomain.py
@@ -51,7 +51,7 @@ chpl_attr_sig_pattern = re.compile(
     r"""^ ((?:\w+\s+)*)?          # optional: prefixes
           ([\w$.]*\.)?            # class name(s)
           ([\w$]+)                # const, var, param, etc name
-          (\s* : \s* [^:]+)?      # optional: type
+          (\s* [:=] \s* [^:=]+)?  # optional: type
           $""", re.VERBOSE)
 
 

--- a/sphinxcontrib/chapeldomain.py
+++ b/sphinxcontrib/chapeldomain.py
@@ -30,7 +30,7 @@ from sphinx.util.docfields import Field, TypedField
 from sphinx.util.nodes import make_refnode
 
 
-VERSION = '0.0.7'
+VERSION = '0.0.8'
 
 
 # regex for parsing proc, iter, class, record, etc.

--- a/test/test_chapeldomain.py
+++ b/test/test_chapeldomain.py
@@ -586,6 +586,9 @@ class AttrSigPatternTests(PatternTestCase):
             ('var RandomStreamPrivate_lock$: _syncvar(bool)', 'var ', None, 'RandomStreamPrivate_lock$', ': _syncvar(bool)'),
             ('var RandomStreamPrivate_lock$: sync bool', 'var ', None, 'RandomStreamPrivate_lock$', ': sync bool'),
             ('const RS$.lock$: sync MyMod$.MyClass$.bool', 'const ', 'RS$.', 'lock$', ': sync MyMod$.MyClass$.bool'),
+            ('type commDiagnostics = chpl_commDiagnostics', 'type ', None, 'commDiagnostics', ' = chpl_commDiagnostics'),
+            ('type age = int(64)', 'type ', None, 'age', ' = int(64)'),
+            ('type MyMod.BigAge=BigNum.BigInt', 'type ', 'MyMod.', 'BigAge', '=BigNum.BigInt'),
         ]
         for sig, prefix, class_name, attr, type_name in test_cases:
             self.check_sig(sig, prefix, class_name, attr, type_name)


### PR DESCRIPTION
Previously, the pattern would not match something like: `type age = int(64)`.

Also, include tests to exercise the regression.
