### PR TITLE
Add symbols from type directives to the index.

### DIFF
--- a/doc-test/classes.rst
+++ b/doc-test/classes.rst
@@ -16,6 +16,14 @@ Chapel classes
     See also :chpl:record:`ChplBigNum`. The :chpl:iter:`these` iterator can be
     used to iterate over the elements of the vector.
 
+    .. attribute:: type eltType
+
+        Generic type for Vector elements.
+
+    .. type:: age = int(64)
+
+        Type alias for tracking age.
+
     .. attribute:: capacity
 
         Integer capacity of vector. See also... random

--- a/doc-test/index.rst
+++ b/doc-test/index.rst
@@ -47,11 +47,11 @@ Module 'Foo'
 
     Default is ``false``.
 
-.. data:: type T: domain(1, int(32), true)
+.. type:: type T = domain(1, int(32), true)
 
     Alias a particular domain to *T*. See also :chpl:type:`U`.
 
-.. type:: U
+.. type:: U = int(64)
 
     I can haz *U*?
 

--- a/sphinxcontrib/chapeldomain.py
+++ b/sphinxcontrib/chapeldomain.py
@@ -507,7 +507,9 @@ class ChapelModuleLevel(ChapelObject):
 
     @property
     def chpl_type_name(self):
-        """Returns iterator or procedure or '' depending on object type."""
+        """Returns type, iterator, or procedure or '' depending on
+        object type.
+        """
         if self.objtype == 'type':
             return 'type'
         elif not self.objtype.endswith('function'):

--- a/sphinxcontrib/chapeldomain.py
+++ b/sphinxcontrib/chapeldomain.py
@@ -30,7 +30,7 @@ from sphinx.util.docfields import Field, TypedField
 from sphinx.util.nodes import make_refnode
 
 
-VERSION = '0.0.8'
+VERSION = '0.0.9'
 
 
 # regex for parsing proc, iter, class, record, etc.

--- a/sphinxcontrib/chapeldomain.py
+++ b/sphinxcontrib/chapeldomain.py
@@ -536,10 +536,13 @@ class ChapelModuleLevel(ChapelObject):
                 return _('%s() (built-in %s)') % \
                     (name_cls[0], self.chpl_type_name)
             return _('%s() (in module %s)') % (name_cls[0], modname)
-        elif self.objtype in ('data'):
+        elif self.objtype in ('data', 'type'):
             if not modname:
-                return _('%s (built-in variable)') % name_cls[0]
-            return _('%s() (in module %s)') % (name_cls[0], modname)
+                type_name = self.objtype
+                if type_name == 'data':
+                    type_name = 'variable'
+                return _('%s (built-in %s)') % (name_cls[0], type_name)
+            return _('%s (in module %s)') % (name_cls[0], modname)
         else:
             return ''
 

--- a/sphinxcontrib/chapeldomain.py
+++ b/sphinxcontrib/chapeldomain.py
@@ -508,14 +508,14 @@ class ChapelModuleLevel(ChapelObject):
     @property
     def chpl_type_name(self):
         """Returns iterator or procedure or '' depending on object type."""
-        if not self.objtype.endswith('function'):
+        if self.objtype == 'type':
+            return 'type'
+        elif not self.objtype.endswith('function'):
             return ''
         elif self.objtype.startswith('iter'):
             return 'iterator'
         elif self.objtype == 'function':
             return 'procedure'
-        elif self.objtype == 'type':
-            return 'type'
         else:
             return ''
 

--- a/test/test_chapeldomain.py
+++ b/test/test_chapeldomain.py
@@ -256,6 +256,20 @@ class ChapelModuleLevelTests(ChapelObjectTestCase):
             mod = self.new_obj(objtype)
             self.assertEqual('', mod.get_index_text('MyMod', ('myThing',)))
 
+    def test_chpl_type_name(self):
+        """Verify chpl_type_name property for different objtypes."""
+        test_cases = [
+            ('function', 'procedure'),
+            ('iterfunction', 'iterator'),
+            ('type', 'type'),
+            ('data', ''),
+            ('method', ''),
+            ('itermethod', ''),
+        ]
+        for objtype, expected_type in test_cases:
+            mod = self.new_obj(objtype)
+            self.assertEqual(expected_type, mod.chpl_type_name)
+
 
 class ChapelObjectTests(ChapelObjectTestCase):
     """ChapelObject tests."""

--- a/test/test_chapeldomain.py
+++ b/test/test_chapeldomain.py
@@ -270,6 +270,20 @@ class ChapelModuleLevelTests(ChapelObjectTestCase):
             mod = self.new_obj(objtype)
             self.assertEqual(expected_type, mod.chpl_type_name)
 
+    def test_needs_arglist(self):
+        """Verify needs_arglist()."""
+        test_cases = [
+            ('function', True),
+            ('iterfunction', True),
+            ('type', False),
+            ('data', False),
+            ('method', False),
+            ('itermethod', False),
+        ]
+        for objtype, expected in test_cases:
+            mod = self.new_obj(objtype)
+            self.assertEqual(expected, mod.needs_arglist())
+
 
 class ChapelObjectTests(ChapelObjectTestCase):
     """ChapelObject tests."""

--- a/test/test_chapeldomain.py
+++ b/test/test_chapeldomain.py
@@ -13,7 +13,7 @@ if sys.version_info[0] == 2 and sys.version_info[1] < 7:
     import unittest2 as unittest
 
 from sphinxcontrib.chapeldomain import (
-    ChapelDomain, ChapelModuleIndex, ChapelObject,
+    ChapelDomain, ChapelModuleIndex, ChapelModuleLevel, ChapelObject,
     chpl_sig_pattern, chpl_attr_sig_pattern,
 )
 
@@ -34,7 +34,7 @@ class ChapelModuleIndexTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """Initalize sphinx locale stuff."""
-        super(cls, ChapelModuleIndexTests).setUpClass()
+        super(ChapelModuleIndexTests, cls).setUpClass()
         import sphinx.locale
         sphinx.locale.init([], 'en')
 
@@ -156,8 +156,17 @@ class ChapelModuleIndexTests(unittest.TestCase):
         self.assertEqual(expected_contents, contents)
 
 
-class ChapelObjectTests(unittest.TestCase):
-    """ChapelObject tests."""
+class ChapelObjectTestCase(unittest.TestCase):
+    """Helper for ChapelObject related tests."""
+
+    object_cls = ChapelObject
+
+    @classmethod
+    def setUpClass(cls):
+        """Initalize sphinx locale stuff."""
+        super(ChapelObjectTestCase, cls).setUpClass()
+        import sphinx.locale
+        sphinx.locale.init([], 'en')
 
     def new_obj(self, objtype, **kwargs):
         """Return new mocked out ChapelObject"""
@@ -173,9 +182,83 @@ class ChapelObjectTests(unittest.TestCase):
             'state_machine': mock.Mock('state_machine'),
         }
         default_args.update(kwargs)
-        o = ChapelObject(**default_args)
+        o = self.object_cls(**default_args)
         o.objtype = objtype
         return o
+
+
+class ChapelModuleLevelTests(ChapelObjectTestCase):
+    """ChapelModuleLevel tests."""
+
+    object_cls = ChapelModuleLevel
+
+    def test_get_index_text__function__no_mod(self):
+        """Verify get_index_text() for function without module."""
+        mod = self.new_obj('function')
+        expected_text = 'myProc() (built-in procedure)'
+        actual_text = mod.get_index_text(None, ('myProc',))
+        self.assertEqual(expected_text, actual_text)
+
+    def test_get_index_text__function__mod(self):
+        """Verify get_index_text() for function with module."""
+        mod = self.new_obj('function')
+        expected_text = 'myProc() (in module MyMod)'
+        actual_text = mod.get_index_text('MyMod', ('myProc',))
+        self.assertEqual(expected_text, actual_text)
+
+    def test_get_index_text__iter__no_mod(self):
+        """Verify get_index_text() for function without module."""
+        mod = self.new_obj('iterfunction')
+        expected_text = 'myProc() (built-in iterator)'
+        actual_text = mod.get_index_text(None, ('myProc',))
+        self.assertEqual(expected_text, actual_text)
+
+    def test_get_index_text__iter__mod(self):
+        """Verify get_index_text() for function with module."""
+        mod = self.new_obj('iterfunction')
+        expected_text = 'myProc() (in module MyMod)'
+        actual_text = mod.get_index_text('MyMod', ('myProc',))
+        self.assertEqual(expected_text, actual_text)
+
+    def test_get_index_text__data__no_mod(self):
+        """Verify get_index_text() for data without module."""
+        mod = self.new_obj('data')
+        expected_text = 'myThing (built-in variable)'
+        actual_text = mod.get_index_text(None, ('myThing',))
+        self.assertEqual(expected_text, actual_text)
+
+    def test_get_index_text__data__mod(self):
+        """Verify get_index_text() for data with module."""
+        mod = self.new_obj('data')
+        expected_text = 'myThing (in module MyMod)'
+        actual_text = mod.get_index_text('MyMod', ('myThing',))
+        self.assertEqual(expected_text, actual_text)
+
+    def test_get_index_text__type__no_mod(self):
+        """Verify get_index_text() for type without module."""
+        mod = self.new_obj('type')
+        expected_text = 'myType (built-in type)'
+        actual_text = mod.get_index_text(None, ('myType',))
+        self.assertEqual(expected_text, actual_text)
+
+    def test_get_index_text__type__mod(self):
+        """Verify get_index_text() for type with module."""
+        mod = self.new_obj('type')
+        expected_text = 'myType (in module MyMod)'
+        actual_text = mod.get_index_text('MyMod', ('myType',))
+        self.assertEqual(expected_text, actual_text)
+
+    def test_get_index_text__other(self):
+        """Verify get_index_text() returns empty string for object types other than
+        function, attribute, and type.
+        """
+        for objtype in ('other', 'attribute', 'class', 'module', 'method', 'itermethod'):
+            mod = self.new_obj(objtype)
+            self.assertEqual('', mod.get_index_text('MyMod', ('myThing',)))
+
+
+class ChapelObjectTests(ChapelObjectTestCase):
+    """ChapelObject tests."""
 
     def test_init(self):
         """Verify ChapelObject can be initialized."""


### PR DESCRIPTION
Previously (due to oversight and lack of use), symbols from type directives were not
added to the index. Update the ChapelModuleLevel.get_index_text() method to
return a string for types.

Add unittests for new behavior and backfill for existing unttested behavior on
ChapelModuleLevel object.
