### PR TITLE
Add additional tests for default globals/fields.

### DIFF
--- a/sphinxcontrib/chapeldomain.py
+++ b/sphinxcontrib/chapeldomain.py
@@ -51,7 +51,7 @@ chpl_attr_sig_pattern = re.compile(
     r"""^ ((?:\w+\s+)*)?          # optional: prefixes
           ([\w$.]*\.)?            # class name(s)
           ([\w$]+)                # const, var, param, etc name
-          (\s* [:=] \s* [^:=]+)?  # optional: type
+          (\s* [:=] \s* .+)?      # optional: type
           $""", re.VERBOSE)
 
 

--- a/test/test_chapeldomain.py
+++ b/test/test_chapeldomain.py
@@ -589,6 +589,10 @@ class AttrSigPatternTests(PatternTestCase):
             ('type commDiagnostics = chpl_commDiagnostics', 'type ', None, 'commDiagnostics', ' = chpl_commDiagnostics'),
             ('type age = int(64)', 'type ', None, 'age', ' = int(64)'),
             ('type MyMod.BigAge=BigNum.BigInt', 'type ', 'MyMod.', 'BigAge', '=BigNum.BigInt'),
+            ('const x = false', 'const ', None, 'x', ' = false'),
+            ('config const MyC.x: int(64) = 5', 'config const ', 'MyC.', 'x', ': int(64) = 5'),
+            ('config param n: uint(64) = 5: uint(64)', 'config param ', None, 'n', ': uint(64) = 5: uint(64)'),
+            ('var MyM.MyC.x = 4: uint(64)', 'var ', 'MyM.MyC.', 'x', ' = 4: uint(64)'),
         ]
         for sig, prefix, class_name, attr, type_name in test_cases:
             self.check_sig(sig, prefix, class_name, attr, type_name)


### PR DESCRIPTION
Discovered issue with conservative character set after : or = in attribute signature.
These tests were suggested in review for previous PR.
