### PR TITLE
Support enum directive for enumerated types.

### DIFF
--- a/doc-test/foo.rst
+++ b/doc-test/foo.rst
@@ -16,3 +16,4 @@ Foo submodules:
 
     This is defined in Foo module!
 
+.. enum:: enum Month { January=1, Februrary, March, April, May, June, July, August, September, October, November, December }

--- a/doc-test/foo.rst
+++ b/doc-test/foo.rst
@@ -17,3 +17,6 @@ Foo submodules:
     This is defined in Foo module!
 
 .. enum:: enum Month { January=1, Februrary, March, April, May, June, July, August, September, October, November, December }
+
+    This is a month enum. The values associated with the constants are the
+    month number. For example, ``Month.January`` has the integer value, ``1``.

--- a/doc-test/index.rst
+++ b/doc-test/index.rst
@@ -55,6 +55,8 @@ Module 'Foo'
 
     I can haz *U*?
 
+.. enum:: enum Color { Red, Yellow, Blue }
+
 Do these XRefs work?
 --------------------
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -116,6 +116,19 @@ For example, this would document a module with a ``proc`` and an ``iter``::
     not documented using this environment (see :rst:dir:`chpl:attribute` for
     that).
 
+.. directive:: .. chpl:enum:: signature
+
+    Describes enumerated type in module, including the constants. For example::
+
+        .. chpl:enum:: Color { Red, Yellow, Blue }
+
+            Supported colors.
+
+        .. chpl:enum:: Weekdays { Sun=0, Mon, Tue, Wed, Thu, Fri, Sat }
+
+            Days for the week. The values associated with the constants can be
+            used with Date records.
+
 .. directive:: .. chpl:class:: signature
 
     Describe a class. The signature can optionally include parentheses with

--- a/sphinxcontrib/chapeldomain.py
+++ b/sphinxcontrib/chapeldomain.py
@@ -741,7 +741,7 @@ class ChapelDomain(Domain):
         'iter': ChapelXRefRole(),
         'class': ChapelXRefRole(),
         'record': ChapelXRefRole(),
-        'enum' : ChapelXRefRole(),
+        'enum': ChapelXRefRole(),
         'meth': ChapelXRefRole(),
         'attr': ChapelXRefRole(),
         'mod': ChapelXRefRole(),

--- a/sphinxcontrib/chapeldomain.py
+++ b/sphinxcontrib/chapeldomain.py
@@ -51,7 +51,7 @@ chpl_attr_sig_pattern = re.compile(
     r"""^ ((?:\w+\s+)*)?          # optional: prefixes
           ([\w$.]*\.)?            # class name(s)
           ([\w$]+)                # const, var, param, etc name
-          (\s* [:={] \s* .+)?     # optional: type
+          (\s* [:={] \s* .+)?     # optional: type, default value
           $""", re.VERBOSE)
 
 

--- a/sphinxcontrib/chapeldomain.py
+++ b/sphinxcontrib/chapeldomain.py
@@ -51,7 +51,7 @@ chpl_attr_sig_pattern = re.compile(
     r"""^ ((?:\w+\s+)*)?          # optional: prefixes
           ([\w$.]*\.)?            # class name(s)
           ([\w$]+)                # const, var, param, etc name
-          (\s* [:=] \s* .+)?      # optional: type
+          (\s* [:={] \s* .+)?     # optional: type
           $""", re.VERBOSE)
 
 
@@ -177,7 +177,7 @@ class ChapelObject(ObjectDescription):
 
     def _is_attr_like(self):
         """Returns True when objtype is attribute or data."""
-        return self.objtype in ('attribute', 'data', 'type')
+        return self.objtype in ('attribute', 'data', 'type', 'enum')
 
     def _is_proc_like(self):
         """Returns True when objtype is *function or *method."""
@@ -538,7 +538,7 @@ class ChapelModuleLevel(ChapelObject):
                 return _('%s() (built-in %s)') % \
                     (name_cls[0], self.chpl_type_name)
             return _('%s() (in module %s)') % (name_cls[0], modname)
-        elif self.objtype in ('data', 'type'):
+        elif self.objtype in ('data', 'type', 'enum'):
             if not modname:
                 type_name = self.objtype
                 if type_name == 'data':
@@ -700,6 +700,7 @@ class ChapelDomain(Domain):
         'type': ObjType(l_('type'), 'type', 'data'),
         'function': ObjType(l_('function'), 'func', 'proc'),
         'iterfunction': ObjType(l_('iterfunction'), 'func', 'iter', 'proc'),
+        'enum': ObjType(l_('enum'), 'enum'),
         'class': ObjType(l_('class'), 'class'),
         'record': ObjType(l_('record'), 'record'),
         'method': ObjType(l_('method'), 'meth', 'proc'),
@@ -713,6 +714,13 @@ class ChapelDomain(Domain):
         'type': ChapelModuleLevel,
         'function': ChapelModuleLevel,
         'iterfunction': ChapelModuleLevel,
+
+        # TODO: Consider making enums ChapelClassObject, then each constant
+        #       becomes an attribute on the class. Then xrefs to each constant
+        #       would be possible, plus it would scale to large numbers of
+        #       constants. (thomasvandoren, 2015-03-12)
+        'enum': ChapelModuleLevel,
+
         'class': ChapelClassObject,
         'record': ChapelClassObject,
         'method': ChapelClassMember,
@@ -733,6 +741,7 @@ class ChapelDomain(Domain):
         'iter': ChapelXRefRole(),
         'class': ChapelXRefRole(),
         'record': ChapelXRefRole(),
+        'enum' : ChapelXRefRole(),
         'meth': ChapelXRefRole(),
         'attr': ChapelXRefRole(),
         'mod': ChapelXRefRole(),

--- a/sphinxcontrib/chapeldomain.py
+++ b/sphinxcontrib/chapeldomain.py
@@ -30,7 +30,7 @@ from sphinx.util.docfields import Field, TypedField
 from sphinx.util.nodes import make_refnode
 
 
-VERSION = '0.0.9'
+VERSION = '0.0.10'
 
 
 # regex for parsing proc, iter, class, record, etc.

--- a/test/test_chapeldomain.py
+++ b/test/test_chapeldomain.py
@@ -296,7 +296,7 @@ class ChapelObjectTests(ChapelObjectTestCase):
         """Verify _is_attr_like return True for data and
         attribute directives.
         """
-        for objtype in ('data', 'attribute', 'type'):
+        for objtype in ('data', 'attribute', 'type', 'enum'):
             self.assertTrue(self.new_obj(objtype)._is_attr_like())
 
     def test_is_attr_like__false(self):
@@ -336,6 +336,7 @@ class ChapelObjectTests(ChapelObjectTestCase):
             'record',
             'module',
             'random',
+            'enum',
             '',
         ]
         for objtype in bad_dirs:
@@ -352,6 +353,7 @@ class ChapelObjectTests(ChapelObjectTestCase):
             ('var x', 'var '),
             ('config const n', 'config const '),
             ('blah blah blah blah blah', 'blah blah blah blah '),
+            ('enum Color', 'enum '),
         ]
         for objtype in ('attribute', 'data'):
             obj = self.new_obj(objtype)

--- a/test/test_chapeldomain.py
+++ b/test/test_chapeldomain.py
@@ -610,7 +610,7 @@ class SigPatternTests(PatternTestCase):
             ('record R', 'record ', None, 'R', None, None),
             ('record MyRec:SuRec', 'record ', None, 'MyRec', None, ':SuRec'),
             ('record N.R : X, Y, Z', 'record ', 'N.', 'R', None, ': X, Y, Z'),
-        ]
+         ]
         for sig, prefix, class_name, name, arglist, retann in test_cases:
             self.check_sig(sig, prefix, class_name, name, arglist, retann)
 
@@ -712,6 +712,9 @@ class AttrSigPatternTests(PatternTestCase):
             ('var MyM.MyC.x = 4: uint(64)', 'var ', 'MyM.MyC.', 'x', ' = 4: uint(64)'),
             ('type MyT = 2*real(64)', 'type ', None, 'MyT', ' = 2*real(64)'),
             ('type myFloats = 2*(real(64))', 'type ', None, 'myFloats', ' = 2*(real(64))'),
+            ('enum Color { Red, Yellow, Blue }', 'enum ', None, 'Color', ' { Red, Yellow, Blue }'),
+            ('enum Month { January=1, February }', 'enum ', None, 'Month', ' { January=1, February }'),
+            ('enum One { Neo }', 'enum ', None, 'One', ' { Neo }'),
         ]
         for sig, prefix, class_name, attr, type_name in test_cases:
             self.check_sig(sig, prefix, class_name, attr, type_name)

--- a/test/test_chapeldomain.py
+++ b/test/test_chapeldomain.py
@@ -604,6 +604,12 @@ class SigPatternTests(PatternTestCase):
             ('proc MyRs(seed: int(64)): int(64)', 'proc ', None, 'MyRs', 'seed: int(64)', ': int(64)'),
             ('proc RandomStream(seed: int(64) = SeedGenerator.currentTime, param parSafe: bool = true)',
              'proc ', None, 'RandomStream', 'seed: int(64) = SeedGenerator.currentTime, param parSafe: bool = true', None),
+            ('class X', 'class ', None, 'X', None, None),
+            ('class MyClass:YourClass', 'class ', None, 'MyClass', None, ':YourClass'),
+            ('class M.C : A, B, C', 'class ', 'M.', 'C', None, ': A, B, C'),
+            ('record R', 'record ', None, 'R', None, None),
+            ('record MyRec:SuRec', 'record ', None, 'MyRec', None, ':SuRec'),
+            ('record N.R : X, Y, Z', 'record ', 'N.', 'R', None, ': X, Y, Z'),
         ]
         for sig, prefix, class_name, name, arglist, retann in test_cases:
             self.check_sig(sig, prefix, class_name, name, arglist, retann)


### PR DESCRIPTION
Add new enum directive, which for now works just like an attribute or
global directive. It does not support sub-directives and the signature
is parsed using the attribute signature.

Update the attribute signature pattern to support enum sigs, like
`enum Color { Red, Yellow, Blue }`.

Update docs to reflect new directive.
