### PR TITLE
Add trivial rst to test c++ domain support for inheritance.

### DIFF
--- a/doc-test/cpp_test.rst
+++ b/doc-test/cpp_test.rst
@@ -1,0 +1,12 @@
+C++ domain test
+===============
+
+.. default-domain:: cpp
+
+.. class:: Base
+
+.. class:: Shape
+
+.. class:: Rectangle : public Shape, Base
+
+

--- a/doc-test/index.rst
+++ b/doc-test/index.rst
@@ -20,6 +20,7 @@ Module 'Foo'
    Vector
    Containers
    foo
+   cpp_test
 
 **Does it work???**
 


### PR DESCRIPTION
Add trivial rst document to doc-test/, which documents three c++ classes that
have inheritance.
