### PR TITLE
Update argument type formatting to be more chapelerific.

### DIFF
--- a/doc-test/functions.rst
+++ b/doc-test/functions.rst
@@ -98,6 +98,15 @@ Chapel Functions
     :ytype: int
     :yields: Fibonacci numbers, first through nth.
 
+.. function:: proc foo(x: int(?bits))
+
+    :type x: int(?bits)
+    :type x: int(32)
+    :arg x: x is good
+    :type x: int
+    :type x: int(64)
+
+
 Other stuff...
 --------------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 docutils
 six
-Sphinx>=1.0
+Sphinx>=1.2.0,<1.2.999

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     install_requires=[
         'docutils',
         'six',
-        'Sphinx>=1.0',
+        'Sphinx>=1.2.0,<1.2.999',
     ],
     namespace_packages=['sphinxcontrib']
 )

--- a/sphinxcontrib/chapeldomain.py
+++ b/sphinxcontrib/chapeldomain.py
@@ -121,15 +121,10 @@ class ChapelObject(ObjectDescription):
 
     doc_field_types = [
         ChapelTypedField('parameter', label=l_('Arguments'),
-                   names=('param', 'parameter', 'arg', 'argument'),
-
-                   # FIXME: Use role name here that exists and is general
-                   #        enough to reference anything... Maybe something
-                   #        like 'class'? (thomasvandoren, 2015-02-04)
-                   typerolename='obj',
-
-                   typenames=('paramtype', 'type'),
-                   can_collapse=True),
+                         names=('param', 'parameter', 'arg', 'argument'),
+                         typerolename='chplref',
+                         typenames=('paramtype', 'type'),
+                         can_collapse=True),
         Field('returnvalue', label=l_('Returns'), has_arg=False,
               names=('returns', 'return')),
         Field('yieldvalue', label=l_('Yields'), has_arg=False,

--- a/sphinxcontrib/chapeldomain.py
+++ b/sphinxcontrib/chapeldomain.py
@@ -30,7 +30,7 @@ from sphinx.util.docfields import Field, TypedField
 from sphinx.util.nodes import make_refnode
 
 
-VERSION = '0.0.10'
+VERSION = '0.0.11'
 
 
 # regex for parsing proc, iter, class, record, etc.

--- a/sphinxcontrib/chapeldomain.py
+++ b/sphinxcontrib/chapeldomain.py
@@ -70,7 +70,7 @@ class ChapelTypedField(TypedField):
     def make_field(self, types, domain, items):
         """Copy+Paste of TypedField.make_field() from Sphinx version 1.2.3. The first
         and second nodes.Text() instance are changed in this implementation to
-        be ' : ' and '' respectively (instead of ' )' and '').
+        be ' : ' and '' respectively (instead of ' (' and ')').
 
         TODO: Ask sphinx devs if there is a better way to support
               this that is less copy+pasty. (thomasvandoren, 2015-03-17)

--- a/sphinxcontrib/chapeldomain.py
+++ b/sphinxcontrib/chapeldomain.py
@@ -64,6 +64,49 @@ chpl_attr_sig_pattern = re.compile(
 #     """Node for a "returns" annotation."""
 # nodes._add_node_class_names([chapel_desc_returns.__name__])
 
+class ChapelTypedField(TypedField):
+    """Override TypedField in order to change output format."""
+
+    def make_field(self, types, domain, items):
+        """Copy+Paste of TypedField.make_field() from Sphinx version 1.2.3. The first
+        and second nodes.Text() instance are changed in this implementation to
+        be ' : ' and '' respectively (instead of ' )' and '').
+
+        TODO: Ask sphinx devs if there is a better way to support
+              this that is less copy+pasty. (thomasvandoren, 2015-03-17)
+        """
+        def handle_item(fieldarg, content):
+            par = nodes.paragraph()
+            par += self.make_xref(
+                self.rolename, domain, fieldarg, nodes.strong)
+            if fieldarg in types:
+                par += nodes.Text(' : ')
+                # NOTE: using .pop() here to prevent a single type node to be
+                # inserted twice into the doctree, which leads to
+                # inconsistencies later when references are resolved
+                fieldtype = types.pop(fieldarg)
+                if (len(fieldtype) == 1 and
+                        isinstance(fieldtype[0], nodes.Text)):
+                    typename = u''.join(n.astext() for n in fieldtype)
+                    par += self.make_xref(self.typerolename, domain, typename)
+                else:
+                    par += fieldtype
+                par += nodes.Text('')
+            par += nodes.Text(' -- ')
+            par += content
+            return par
+
+        fieldname = nodes.field_name('', self.label)
+        if len(items) == 1 and self.can_collapse:
+            fieldarg, content = items[0]
+            bodynode = handle_item(fieldarg, content)
+        else:
+            bodynode = self.list_type()
+            for fieldarg, content in items:
+                bodynode += nodes.list_item('', handle_item(fieldarg, content))
+        fieldbody = nodes.field_body('', bodynode)
+        return nodes.field('', fieldname, fieldbody)
+
 
 class ChapelObject(ObjectDescription):
     """Base class for Chapel directives. It has methods for parsing signatures of
@@ -77,7 +120,7 @@ class ChapelObject(ObjectDescription):
     }
 
     doc_field_types = [
-        TypedField('parameter', label=l_('Arguments'),
+        ChapelTypedField('parameter', label=l_('Arguments'),
                    names=('param', 'parameter', 'arg', 'argument'),
 
                    # FIXME: Use role name here that exists and is general


### PR DESCRIPTION
Update argument type formatting to use the form `argname : type -- description`,
instead of `argname (type) -- description`. The new form is considered more
"chapelerific" since it matches the argument type syntax.

Unfortunately the sphinx.utils.docfields.TypedField.make_field() method is not
implemented in such a way that allows this formatting change without fully
overriding the meth. So, copy the TypedField.make_field() method from Sphinx
version 1.2.3 and modify the two Text() nodes that add the parentheses.

Because of how ChapelTypedField.make_field() is implemented, this package
is not dependent on Sphinx 1.2.x. There is probably a way to support both
Sphinx 1.2.x and the recently released Sphinx 1.3.x, but that is beyond the
scope of this change. In an ideal world, the three formatting strings in
TypedField.make_field() (`' ('`, `')'`, and `' -- '`) would be configurable without
needing to override make_field().

The source from Sphinx 1.2.3 can be found here:

https://github.com/sphinx-doc/sphinx/blob/1.2.3/sphinx/util/docfields.py#L137-166
