### PR TITLE
Update parser to support signatures with both return intent and type.

### DIFF
--- a/doc-test/functions.rst
+++ b/doc-test/functions.rst
@@ -106,6 +106,14 @@ Chapel Functions
     :type x: int
     :type x: int(64)
 
+.. function:: proc rcRemote(replicatedVar: [?D] ?MYTYPE, remoteLoc: locale) ref: MYTYPE
+
+    Remote stuff... :proc:`rcLocal`
+
+.. function:: proc rcLocal(replicatedVar: [?D] ?MYTYPE) ref: MYTYPE
+
+    Local stuff... :proc:`rcRemote`
+
 
 Other stuff...
 --------------

--- a/sphinxcontrib/chapeldomain.py
+++ b/sphinxcontrib/chapeldomain.py
@@ -30,7 +30,7 @@ from sphinx.util.docfields import Field, TypedField
 from sphinx.util.nodes import make_refnode
 
 
-VERSION = '0.0.11'
+VERSION = '0.0.12'
 
 
 # regex for parsing proc, iter, class, record, etc.

--- a/sphinxcontrib/chapeldomain.py
+++ b/sphinxcontrib/chapeldomain.py
@@ -41,8 +41,9 @@ chpl_sig_pattern = re.compile(
           ([\w$.]*\.)?                   # class name(s)
           ([\w\+\-/\*$]+)  \s*           # function or method name
           (?:\((.*?)\))?                 # optional: arguments
-          (\s+ \w+|                      #   or ref intent
-           \s* : \s* [^:]+               #   or return type
+          (\s+ \w+|                      #   or return intent
+           \s* : \s* [^:]+|              #   or return type
+           \s+ \w+\s* : \s* [^:]+        #   or return intent and type
           )?
           $""", re.VERBOSE)
 

--- a/sphinxcontrib/chapeldomain.py
+++ b/sphinxcontrib/chapeldomain.py
@@ -41,8 +41,8 @@ chpl_sig_pattern = re.compile(
           ([\w$.]*\.)?                   # class name(s)
           ([\w\+\-/\*$]+)  \s*           # function or method name
           (?:\((.*?)\))?                 # optional: arguments
-          (\s* : \s* [^:]+|              #   or return type
-           \s+ \w+                       #   or ref intent
+          (\s+ \w+|                      #   or ref intent
+           \s* : \s* [^:]+               #   or return type
           )?
           $""", re.VERBOSE)
 

--- a/test/test_chapeldomain.py
+++ b/test/test_chapeldomain.py
@@ -690,6 +690,10 @@ class SigPatternTests(PatternTestCase):
             ('record R', 'record ', None, 'R', None, None),
             ('record MyRec:SuRec', 'record ', None, 'MyRec', None, ':SuRec'),
             ('record N.R : X, Y, Z', 'record ', 'N.', 'R', None, ': X, Y, Z'),
+            ('proc rcRemote(replicatedVar: [?D] ?MYTYPE, remoteLoc: locale) ref: MYTYPE',
+             'proc ', None, 'rcRemote', 'replicatedVar: [?D] ?MYTYPE, remoteLoc: locale', ' ref: MYTYPE'),
+            ('proc rcLocal(replicatedVar: [?D] ?MYTYPE) ref: MYTYPE',
+             'proc ', None, 'rcLocal', 'replicatedVar: [?D] ?MYTYPE', ' ref: MYTYPE'),
          ]
         for sig, prefix, class_name, name, arglist, retann in test_cases:
             self.check_sig(sig, prefix, class_name, name, arglist, retann)


### PR DESCRIPTION
Previously, signatures with both return intent and type would not
parse correctly, e.g. `proc foo() ref: int`. Update the signature
regex to support signatures with both a return intent and a return
type.

Add unittest and acceptance test to doc-test/.
