### PR TITLE
Fix output for type and param methods

### DIFF
--- a/doc-test/classes.rst
+++ b/doc-test/classes.rst
@@ -43,6 +43,14 @@ Chapel classes
 
         Instance lock that ensures certain operations are serialized.
 
+    .. method:: proc type currentTime: int(64)
+
+
+        Generate a seed based on the current time in microseconds as
+        reported by :proc:`Time.getCurrentTime`. This seed is not
+        suitable for the NPB RNG since that requires an odd seed.
+
+
     .. method:: ChplVector(type eltType, cap=4, offset=0)
 
         Initialize new generic ChplVector of type eltType. See

--- a/sphinxcontrib/chapeldomain.py
+++ b/sphinxcontrib/chapeldomain.py
@@ -37,7 +37,7 @@ VERSION = '0.0.12'
 chpl_sig_pattern = re.compile(
     r"""^ ((?:\w+\s+)*                   # optional: prefixes
            (?:proc|iter|class|record)\s+ #   must end with keyword
-           ((?:type|param)\s)?           # optional: type or param method
+           (?:type\s+|param\s+)?         # optional: type or param method
           )?
           ([\w$.]*\.)?                   # class name(s)
           ([\w\+\-/\*$]+)  \s*           # function or method name

--- a/sphinxcontrib/chapeldomain.py
+++ b/sphinxcontrib/chapeldomain.py
@@ -37,6 +37,7 @@ VERSION = '0.0.12'
 chpl_sig_pattern = re.compile(
     r"""^ ((?:\w+\s+)*                   # optional: prefixes
            (?:proc|iter|class|record)\s+ #   must end with keyword
+           ((?:type|param)\s)?           # optional: type or param method
           )?
           ([\w$.]*\.)?                   # class name(s)
           ([\w\+\-/\*$]+)  \s*           # function or method name

--- a/test/test_chapeldomain.py
+++ b/test/test_chapeldomain.py
@@ -681,6 +681,8 @@ class SigPatternTests(PatternTestCase):
             ('proc Util.toVector(type eltType, cap=4, offset=0): Containers.Vector', 'proc ', 'Util.', 'toVector', 'type eltType, cap=4, offset=0', ': Containers.Vector'),
             ('proc MyClass$.lock$(combo$): sync bool', 'proc ', 'MyClass$.', 'lock$', 'combo$', ': sync bool'),
             ('proc MyClass$.lock$(combo$): sync myBool$', 'proc ', 'MyClass$.', 'lock$', 'combo$', ': sync myBool$'),
+            ('proc type currentTime(): int(64)', 'proc type ', None, 'currentTime', '', ': int(64)'),
+            ('proc param int.someNum(): int(64)', 'proc param', 'int', 'someNum', '', ': int(64)'),
             ('proc MyRs(seed: int(64)): int(64)', 'proc ', None, 'MyRs', 'seed: int(64)', ': int(64)'),
             ('proc RandomStream(seed: int(64) = SeedGenerator.currentTime, param parSafe: bool = true)',
              'proc ', None, 'RandomStream', 'seed: int(64) = SeedGenerator.currentTime, param parSafe: bool = true', None),

--- a/test/test_chapeldomain.py
+++ b/test/test_chapeldomain.py
@@ -682,7 +682,7 @@ class SigPatternTests(PatternTestCase):
             ('proc MyClass$.lock$(combo$): sync bool', 'proc ', 'MyClass$.', 'lock$', 'combo$', ': sync bool'),
             ('proc MyClass$.lock$(combo$): sync myBool$', 'proc ', 'MyClass$.', 'lock$', 'combo$', ': sync myBool$'),
             ('proc type currentTime(): int(64)', 'proc type ', None, 'currentTime', '', ': int(64)'),
-            ('proc param int.someNum(): int(64)', 'proc param', 'int', 'someNum', '', ': int(64)'),
+            ('proc param int.someNum(): int(64)', 'proc param ', 'int', 'someNum', '', ': int(64)'),
             ('proc MyRs(seed: int(64)): int(64)', 'proc ', None, 'MyRs', 'seed: int(64)', ': int(64)'),
             ('proc RandomStream(seed: int(64) = SeedGenerator.currentTime, param parSafe: bool = true)',
              'proc ', None, 'RandomStream', 'seed: int(64) = SeedGenerator.currentTime, param parSafe: bool = true', None),

--- a/test/test_chapeldomain.py
+++ b/test/test_chapeldomain.py
@@ -682,7 +682,7 @@ class SigPatternTests(PatternTestCase):
             ('proc MyClass$.lock$(combo$): sync bool', 'proc ', 'MyClass$.', 'lock$', 'combo$', ': sync bool'),
             ('proc MyClass$.lock$(combo$): sync myBool$', 'proc ', 'MyClass$.', 'lock$', 'combo$', ': sync myBool$'),
             ('proc type currentTime(): int(64)', 'proc type ', None, 'currentTime', '', ': int(64)'),
-            ('proc param int.someNum(): int(64)', 'proc param ', 'int', 'someNum', '', ': int(64)'),
+            ('proc param int.someNum(): int(64)', 'proc param ', 'int.', 'someNum', '', ': int(64)'),
             ('proc MyRs(seed: int(64)): int(64)', 'proc ', None, 'MyRs', 'seed: int(64)', ': int(64)'),
             ('proc RandomStream(seed: int(64) = SeedGenerator.currentTime, param parSafe: bool = true)',
              'proc ', None, 'RandomStream', 'seed: int(64) = SeedGenerator.currentTime, param parSafe: bool = true', None),


### PR DESCRIPTION
Before, the Sphinx output for methods of the form `proc type foo` and `proc
param foo` (the latter of which was only applicable to types which support
param, such as primitives like ints) would get somewhat messed up, as the domain
wasn't aware that these were prefix keywords and tried to treat them like names
for the methods.  This also broke linking to the methods.  With this change,
the Sphinx output should be improved.

Also added test coverage for the new cases.
