### PR TITLE
Fix error with handling of const ref return intents

### DIFF
--- a/doc-test/functions.rst
+++ b/doc-test/functions.rst
@@ -114,6 +114,12 @@ Chapel Functions
 
     Local stuff... :proc:`rcRemote`
 
+.. function:: proc specialArg(const ref x: int)
+
+.. function:: proc specialReturn() const ref
+
+.. function:: proc constRefArgAndReturn(const ref x: int) const ref
+
 
 Other stuff...
 --------------

--- a/sphinxcontrib/chapeldomain.py
+++ b/sphinxcontrib/chapeldomain.py
@@ -35,16 +35,16 @@ VERSION = '0.0.13'
 
 # regex for parsing proc, iter, class, record, etc.
 chpl_sig_pattern = re.compile(
-    r"""^ ((?:\w+\s+)*                    # optional: prefixes
-           (?:proc|iter|class|record)\s+  #   must end with keyword
-           (?:type\s+|param\s+)?          # optional: type or param method
+    r"""^ ((?:\w+\s+)*                     # optional: prefixes
+           (?:proc|iter|class|record)\s+   #   must end with keyword
+           (?:type\s+|param\s+)?           # optional: type or param method
           )?
-          ([\w$.]*\.)?                    # class name(s)
-          ([\w\+\-/\*$]+)  \s*            # function or method name
-          (?:\((.*?)\))?                  # optional: arguments
-          ((\s+ \w+){1, 2}|               #   or return intent
-           \s* : \s* [^:]+|               #   or return type
-           (\s+ \w+){1, 2}\s* : \s* [^:]+ #   or return intent and type
+          ([\w$.]*\.)?                     # class name(s)
+          ([\w\+\-/\*$]+)  \s*             # function or method name
+          (?:\((.*?)\))?                   # optional: arguments
+          (( const)?\s+ \w+|               #   or return intent
+           \s* : \s* [^:]+|                #   or return type
+           ( const)?\s+ \w+\s* : \s* [^:]+ #   or return intent and type
           )?
           $""", re.VERBOSE)
 

--- a/sphinxcontrib/chapeldomain.py
+++ b/sphinxcontrib/chapeldomain.py
@@ -35,16 +35,16 @@ VERSION = '0.0.13'
 
 # regex for parsing proc, iter, class, record, etc.
 chpl_sig_pattern = re.compile(
-    r"""^ ((?:\w+\s+)*                   # optional: prefixes
-           (?:proc|iter|class|record)\s+ #   must end with keyword
-           (?:type\s+|param\s+)?         # optional: type or param method
+    r"""^ ((?:\w+\s+)*                    # optional: prefixes
+           (?:proc|iter|class|record)\s+  #   must end with keyword
+           (?:type\s+|param\s+)?          # optional: type or param method
           )?
-          ([\w$.]*\.)?                   # class name(s)
-          ([\w\+\-/\*$]+)  \s*           # function or method name
-          (?:\((.*?)\))?                 # optional: arguments
-          (\s+ \w+|                      #   or return intent
-           \s* : \s* [^:]+|              #   or return type
-           \s+ \w+\s* : \s* [^:]+        #   or return intent and type
+          ([\w$.]*\.)?                    # class name(s)
+          ([\w\+\-/\*$]+)  \s*            # function or method name
+          (?:\((.*?)\))?                  # optional: arguments
+          ((\s+ \w+){1, 2}|               #   or return intent
+           \s* : \s* [^:]+|               #   or return type
+           (\s+ \w+){1, 2}\s* : \s* [^:]+ #   or return intent and type
           )?
           $""", re.VERBOSE)
 

--- a/sphinxcontrib/chapeldomain.py
+++ b/sphinxcontrib/chapeldomain.py
@@ -30,7 +30,7 @@ from sphinx.util.docfields import Field, TypedField
 from sphinx.util.nodes import make_refnode
 
 
-VERSION = '0.0.13'
+VERSION = '0.0.14'
 
 
 # regex for parsing proc, iter, class, record, etc.

--- a/sphinxcontrib/chapeldomain.py
+++ b/sphinxcontrib/chapeldomain.py
@@ -35,15 +35,15 @@ VERSION = '0.0.13'
 
 # regex for parsing proc, iter, class, record, etc.
 chpl_sig_pattern = re.compile(
-    r"""^ ((?:\w+\s+)*                     # optional: prefixes
-           (?:proc|iter|class|record)\s+   #   must end with keyword
-           (?:type\s+|param\s+)?           # optional: type or param method
+    r"""^ ((?:\w+\s+)*                        # optional: prefixes
+           (?:proc|iter|class|record)\s+      #   must end with keyword
+           (?:type\s+|param\s+)?              # optional: type or param method
           )?
-          ([\w$.]*\.)?                     # class name(s)
-          ([\w\+\-/\*$]+)  \s*             # function or method name
-          (?:\((.*?)\))?                   # optional: arguments
-          (\s+(?:const\s)? \w+|              #   or return intent
-           \s* : \s* [^:]+|                #   or return type
+          ([\w$.]*\.)?                        # class name(s)
+          ([\w\+\-/\*$]+)  \s*                # function or method name
+          (?:\((.*?)\))?                      # optional: arguments
+          (\s+(?:const\s)? \w+|               #   or return intent
+           \s* : \s* [^:]+|                   #   or return type
            \s+(?:const\s)? \w+\s* : \s* [^:]+ #   or return intent and type
           )?
           $""", re.VERBOSE)

--- a/sphinxcontrib/chapeldomain.py
+++ b/sphinxcontrib/chapeldomain.py
@@ -42,9 +42,9 @@ chpl_sig_pattern = re.compile(
           ([\w$.]*\.)?                     # class name(s)
           ([\w\+\-/\*$]+)  \s*             # function or method name
           (?:\((.*?)\))?                   # optional: arguments
-          (( const)?\s+ \w+|               #   or return intent
+          (\s+(?:const\s)? \w+|              #   or return intent
            \s* : \s* [^:]+|                #   or return type
-           ( const)?\s+ \w+\s* : \s* [^:]+ #   or return intent and type
+           \s+(?:const\s)? \w+\s* : \s* [^:]+ #   or return intent and type
           )?
           $""", re.VERBOSE)
 

--- a/test/test_chapeldomain.py
+++ b/test/test_chapeldomain.py
@@ -697,7 +697,7 @@ class SigPatternTests(PatternTestCase):
             ('proc rcLocal(replicatedVar: [?D] ?MYTYPE) ref: MYTYPE',
              'proc ', None, 'rcLocal', 'replicatedVar: [?D] ?MYTYPE', ' ref: MYTYPE'),
             ('proc specialArg(const ref x: int)', 'proc ', None, 'specialArg', 'const ref x: int', None),
-            #('proc specialReturn() const ref', 'proc ', None, 'specialReturn', '', ' const ref'),
+            ('proc specialReturn() const ref', 'proc ', None, 'specialReturn', '', ' const ref'),
             ('proc constRefArgAndReturn(const ref x: int) const ref', 'proc ', None, 'constRefArgAndReturn', 'const ref x: int', ' const ref'),
          ]
         for sig, prefix, class_name, name, arglist, retann in test_cases:

--- a/test/test_chapeldomain.py
+++ b/test/test_chapeldomain.py
@@ -697,7 +697,7 @@ class SigPatternTests(PatternTestCase):
             ('proc rcLocal(replicatedVar: [?D] ?MYTYPE) ref: MYTYPE',
              'proc ', None, 'rcLocal', 'replicatedVar: [?D] ?MYTYPE', ' ref: MYTYPE'),
             ('proc specialArg(const ref x: int)', 'proc ', None, 'specialArg', 'const ref x: int', None),
-            ('proc specialReturn() const ref', 'proc ', None, 'specialReturn', None, ' const ref'),
+            ('proc specialReturn() const ref', 'proc ', None, 'specialReturn', '', ' const ref'),
             ('proc constRefArgAndReturn(const ref x: int) const ref', 'proc ', None, 'constRefArgAndReturn', 'const ref x: int', ' const ref'),
          ]
         for sig, prefix, class_name, name, arglist, retann in test_cases:

--- a/test/test_chapeldomain.py
+++ b/test/test_chapeldomain.py
@@ -696,6 +696,9 @@ class SigPatternTests(PatternTestCase):
              'proc ', None, 'rcRemote', 'replicatedVar: [?D] ?MYTYPE, remoteLoc: locale', ' ref: MYTYPE'),
             ('proc rcLocal(replicatedVar: [?D] ?MYTYPE) ref: MYTYPE',
              'proc ', None, 'rcLocal', 'replicatedVar: [?D] ?MYTYPE', ' ref: MYTYPE'),
+            ('proc specialArg(const ref x: int)', 'proc', None, 'specialArg', 'const ref x:int', None),
+            ('proc specialReturn() const ref', 'proc', None, 'specialReturn', None, ' const ref'),
+            ('proc constRefArgAndReturn(const ref x: int) const ref', 'proc', None, 'constRefArgAndReturn', 'const ref x: int', ' const ref'),
          ]
         for sig, prefix, class_name, name, arglist, retann in test_cases:
             self.check_sig(sig, prefix, class_name, name, arglist, retann)

--- a/test/test_chapeldomain.py
+++ b/test/test_chapeldomain.py
@@ -696,7 +696,7 @@ class SigPatternTests(PatternTestCase):
              'proc ', None, 'rcRemote', 'replicatedVar: [?D] ?MYTYPE, remoteLoc: locale', ' ref: MYTYPE'),
             ('proc rcLocal(replicatedVar: [?D] ?MYTYPE) ref: MYTYPE',
              'proc ', None, 'rcLocal', 'replicatedVar: [?D] ?MYTYPE', ' ref: MYTYPE'),
-            ('proc specialArg(const ref x: int)', 'proc ', None, 'specialArg', 'const ref x:int', None),
+            ('proc specialArg(const ref x: int)', 'proc ', None, 'specialArg', 'const ref x: int', None),
             ('proc specialReturn() const ref', 'proc ', None, 'specialReturn', None, ' const ref'),
             ('proc constRefArgAndReturn(const ref x: int) const ref', 'proc ', None, 'constRefArgAndReturn', 'const ref x: int', ' const ref'),
          ]

--- a/test/test_chapeldomain.py
+++ b/test/test_chapeldomain.py
@@ -696,9 +696,9 @@ class SigPatternTests(PatternTestCase):
              'proc ', None, 'rcRemote', 'replicatedVar: [?D] ?MYTYPE, remoteLoc: locale', ' ref: MYTYPE'),
             ('proc rcLocal(replicatedVar: [?D] ?MYTYPE) ref: MYTYPE',
              'proc ', None, 'rcLocal', 'replicatedVar: [?D] ?MYTYPE', ' ref: MYTYPE'),
-            ('proc specialArg(const ref x: int)', 'proc', None, 'specialArg', 'const ref x:int', None),
-            ('proc specialReturn() const ref', 'proc', None, 'specialReturn', None, ' const ref'),
-            ('proc constRefArgAndReturn(const ref x: int) const ref', 'proc', None, 'constRefArgAndReturn', 'const ref x: int', ' const ref'),
+            ('proc specialArg(const ref x: int)', 'proc ', None, 'specialArg', 'const ref x:int', None),
+            ('proc specialReturn() const ref', 'proc ', None, 'specialReturn', None, ' const ref'),
+            ('proc constRefArgAndReturn(const ref x: int) const ref', 'proc ', None, 'constRefArgAndReturn', 'const ref x: int', ' const ref'),
          ]
         for sig, prefix, class_name, name, arglist, retann in test_cases:
             self.check_sig(sig, prefix, class_name, name, arglist, retann)

--- a/test/test_chapeldomain.py
+++ b/test/test_chapeldomain.py
@@ -697,7 +697,7 @@ class SigPatternTests(PatternTestCase):
             ('proc rcLocal(replicatedVar: [?D] ?MYTYPE) ref: MYTYPE',
              'proc ', None, 'rcLocal', 'replicatedVar: [?D] ?MYTYPE', ' ref: MYTYPE'),
             ('proc specialArg(const ref x: int)', 'proc ', None, 'specialArg', 'const ref x: int', None),
-            ('proc specialReturn() const ref', 'proc ', None, 'specialReturn', '', ' const ref'),
+            #('proc specialReturn() const ref', 'proc ', None, 'specialReturn', '', ' const ref'),
             ('proc constRefArgAndReturn(const ref x: int) const ref', 'proc ', None, 'constRefArgAndReturn', 'const ref x: int', ' const ref'),
          ]
         for sig, prefix, class_name, name, arglist, retann in test_cases:


### PR DESCRIPTION
As seen on master's version of the Reflection module, functions with
the declaration:

`proc getField(const ref x: ?t, param i: int) const ref`

would not properly render.  The issue turned out to be specific to the
const ref return intent (the argument intent was fine).  Fix the regex
for reading function declarations, and add the tests I used to narrow
down the source of the issue and ensure it was resolved (argument
intent only, return intent only, combination of argument intent and
return intent).
