### PR TITLE
Updates to match Sphinx 1.6 interface changes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 docutils
 six
-Sphinx>=1.2.0,<1.2.999
+Sphinx>=1.6.0,<1.6.999

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     install_requires=[
         'docutils',
         'six',
-        'Sphinx>=1.2.0,<1.2.999',
+        'Sphinx>=1.6.0,<1.6.999',
     ],
     namespace_packages=['sphinxcontrib']
 )

--- a/sphinxcontrib/chapeldomain.py
+++ b/sphinxcontrib/chapeldomain.py
@@ -25,7 +25,7 @@ from sphinx.directives import ObjectDescription
 from sphinx.domains import Domain, Index, ObjType
 from sphinx.locale import l_, _
 from sphinx.roles import XRefRole
-from sphinx.util.compat import Directive
+from docutils.parsers.rst import Directive
 from sphinx.util.docfields import Field, TypedField
 from sphinx.util.nodes import make_refnode
 
@@ -69,7 +69,7 @@ chpl_attr_sig_pattern = re.compile(
 class ChapelTypedField(TypedField):
     """Override TypedField in order to change output format."""
 
-    def make_field(self, types, domain, items):
+    def make_field(self, types, domain, items, env=None):
         """Copy+Paste of TypedField.make_field() from Sphinx version 1.2.3. The first
         and second nodes.Text() instance are changed in this implementation to
         be ' : ' and '' respectively (instead of ' (' and ')').
@@ -365,7 +365,7 @@ class ChapelObject(ObjectDescription):
         indextext = self.get_index_text(modname, name_cls)
         if indextext:
             self.indexnode['entries'].append(('single', indextext,
-                                              fullname, ''))
+                                              fullname, '', None))
 
     def before_content(self):
         """Called before parsing content. Set flag to help with class scoping.
@@ -426,7 +426,7 @@ class ChapelModule(Directive):
             ret.append(targetnode)
             indextext = _('%s (module)') % modname
             inode = addnodes.index(entries=[('single', indextext,
-                                             'module-' + modname, '')])
+                                             'module-' + modname, '', None)])
             ret.append(inode)
         return ret
 


### PR DESCRIPTION
Sphinx made some breaking changes between 1.2 and 1.6. This PR fixes
them for chapeldomain extension. 

Interface changes that were adjusted:

- `make_field` now requires an env argument (ignored by our implementation)
- `sphinx.util.compat.Directive` deprecated for `docutils.parsers.rst.Directive`
- `indexnode` is now a 5-element tuple instead of 4

## Testing
- [x] Builds Chapel's documentation
- [x] Passes nosetests
- [ ] Passes docs tests
  
  Closes #29