### PR TITLE
Modify function regex to support operators

### DIFF
--- a/doc-test/functions.rst
+++ b/doc-test/functions.rst
@@ -120,6 +120,8 @@ Chapel Functions
 
 .. function:: proc constRefArgAndReturn(const ref x: int) const ref
 
+.. function:: proc <(x, y)
+
 
 Other stuff...
 --------------

--- a/sphinxcontrib/chapeldomain.py
+++ b/sphinxcontrib/chapeldomain.py
@@ -40,7 +40,7 @@ chpl_sig_pattern = re.compile(
            (?:type\s+|param\s+)?              # optional: type or param method
           )?
           ([\w$.]*\.)?                        # class name(s)
-          ([\w\+\-/\*$]+)  \s*                # function or method name
+          ([\w\+\-/\*$\<\=\>\!]+)  \s*        # function or method name
           (?:\((.*?)\))?                      # optional: arguments
           (\s+(?:const\s)? \w+|               #   or return intent
            \s* : \s* [^:]+|                   #   or return type


### PR DESCRIPTION
In conjunction with https://github.com/chapel-lang/chapel/pull/10983, this PR adds support for displaying operator procedures correctly, e.g.

```chpl
proc <(a, b) { }
```

Thank you @mppf for the regex edit