### PR TITLE
Add support for a :throw(s): tag for functions and iterators

### DIFF
--- a/doc-test/functions.rst
+++ b/doc-test/functions.rst
@@ -122,6 +122,23 @@ Chapel Functions
 
 .. function:: proc <(x, y)
 
+.. function:: proc throwsAnError() throws
+
+    :throw FileNotFoundError: looks at a file that doesn't exist
+
+.. function:: proc throwsVariousErrors(x: bool) throws
+
+    :arg x: determines whether to check a directory or a file
+    :type x: bool
+    :throw IsADirectoryError: makes a directory and does something dumb
+    :throw NotADirectoryError: makes a file that it treats like a directory
+
+.. function:: proc throwsOrReturns(): string throws
+
+    :return: a message for you!
+    :rtype: string
+    :throw PermissionError: when the message is not for you
+
 
 Other stuff...
 --------------

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -87,6 +87,7 @@ For example, this would document a module with a ``proc`` and an ``iter``::
         :type n: int
         :rtype: BigNum
         :returns: ``n!``
+        :throw TimeoutError: if the the computation takes too long
 
     .. chpl:iterfunction:: iter fibonacci(): BigNum
 

--- a/sphinxcontrib/chapeldomain.py
+++ b/sphinxcontrib/chapeldomain.py
@@ -26,7 +26,7 @@ from sphinx.domains import Domain, Index, ObjType
 from sphinx.locale import l_, _
 from sphinx.roles import XRefRole
 from sphinx.util.compat import Directive
-from sphinx.util.docfields import Field, TypedField
+from sphinx.util.docfields import Field, GroupedField, TypedField
 from sphinx.util.nodes import make_refnode
 
 

--- a/sphinxcontrib/chapeldomain.py
+++ b/sphinxcontrib/chapeldomain.py
@@ -30,7 +30,7 @@ from sphinx.util.docfields import Field, GroupedField, TypedField
 from sphinx.util.nodes import make_refnode
 
 
-VERSION = '0.0.14'
+VERSION = '0.0.15'
 
 
 # regex for parsing proc, iter, class, record, etc.

--- a/sphinxcontrib/chapeldomain.py
+++ b/sphinxcontrib/chapeldomain.py
@@ -135,6 +135,8 @@ class ChapelObject(ObjectDescription):
               names=('rtype',)),
         Field('yieldtype', label=l_('Yield type'), has_arg=False,
               names=('ytype',)),
+        GroupedField('errorhandling', label=l_('Throws'),
+                     names=('throw', 'throws'), can_collapse=True),
     ]
 
     @staticmethod


### PR DESCRIPTION
The formatting is similar to :arg name: (because that's how the example I saw
did it for Python errors), but it doesn't allow a :type name: extension
(because that seemed silly to me).  Throw lists should be after both arguments
and return types (because that's how it is in Chapel function declarations).

This supports both `:throw:` and `:throws:` (similar to how we support both
`:return:` and `:returns:`)

Example - for a function defined as:

```chapel
proc foo(x: int): string throws { ... }
```

We expect to write the following documentation:
```
Something about foo

:arg x: some number
:type x: `int`
:return: some message
:rtype: `string`
:throws SomeError: should some condition occur
:throws SomeDifferentError: should some other condition occur
```

Adds some documentation tests to verify that this works.