### PR TITLE
Use older version of docutils

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-docutils
+docutils<=0.14
 six
 Sphinx>=1.2.0,<1.2.999


### PR DESCRIPTION
docutils 0.15 does not allow us to import nodes any more, when 0.14 does.  We
should update the implementation to be compliant with later versions, but that's
not a priority at the moment, so pin for now.