### PR TITLE
Update to require Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - 3.5
+  - 3.6
 install:
   - pip install -r requirements.txt -r test-requirements.txt -r docs-requirements.txt
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
-  - 2.7
-  - 3.4
+  - 3.5
 install:
   - pip install -r requirements.txt -r test-requirements.txt -r docs-requirements.txt
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
   - 3.6
 install:
-  - pip install -r requirements.txt -r test-requirements.txt -r docs-requirements.txt
+  - python3 -m pip install -r requirements.txt -r test-requirements.txt -r docs-requirements.txt
 script:
   - flake8 sphinxcontrib/
   - nosetests --verbose --with-cov --cov-report xml --cover-package=sphinxcontrib.chapeldomain

--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ Installation
 
 To install::
 
-    pip install sphinxcontrib-chapeldomain
+    python3 -m pip install sphinxcontrib-chapeldomain
 
 To install from source on github_::
 

--- a/docs/developers.rst
+++ b/docs/developers.rst
@@ -20,7 +20,7 @@ Overview
     git clone <url_for_fork>
     cd sphinxcontrib-chapeldomain/
     git checkout -b <branch_name>
-    pip install -r requirements.txt -r test-requirements.txt
+    python3 -m pip install -r requirements.txt -r test-requirements.txt
     ... develop ...
     tox
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,7 +18,7 @@ Installation
 
 To install::
 
-    pip install sphinxcontrib-chapeldomain
+    python3 -m pip install sphinxcontrib-chapeldomain
 
 To install from source on github_::
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 docutils<=0.14
 six
-Sphinx==1.8.5
+Sphinx==3.2.1

--- a/setup.py
+++ b/setup.py
@@ -42,9 +42,9 @@ setup(
     packages=find_packages(exclude=('test',)),
     include_package_data=True,
     install_requires=[
-        'docutils',
+        'docutils<=0.14',
         'six',
-        'Sphinx>=1.6.0,<1.6.999',
+        'Sphinx>1.8.5,<=3.2.1',
     ],
     namespace_packages=['sphinxcontrib']
 )

--- a/setup.py
+++ b/setup.py
@@ -42,9 +42,9 @@ setup(
     packages=find_packages(exclude=('test',)),
     include_package_data=True,
     install_requires=[
-        'docutils<=0.14',
+        'docutils',
         'six',
-        'Sphinx>1.8.5,<=3.2.1',
+        'Sphinx',
     ],
     namespace_packages=['sphinxcontrib']
 )

--- a/sphinxcontrib/chapeldomain/__init__.py
+++ b/sphinxcontrib/chapeldomain/__init__.py
@@ -23,7 +23,7 @@ from six import iteritems
 from sphinx import addnodes
 from sphinx.directives import ObjectDescription
 from sphinx.domains import Domain, Index, ObjType
-from sphinx.locale import l_, _
+from sphinx.locale import _
 from sphinx.roles import XRefRole
 from docutils.parsers.rst import Directive
 from sphinx.util.docfields import Field, GroupedField, TypedField
@@ -122,20 +122,20 @@ class ChapelObject(ObjectDescription):
     }
 
     doc_field_types = [
-        ChapelTypedField('parameter', label=l_('Arguments'),
+        ChapelTypedField('parameter', label=_('Arguments'),
                          names=('param', 'parameter', 'arg', 'argument'),
                          typerolename='chplref',
                          typenames=('paramtype', 'type'),
                          can_collapse=True),
-        Field('returnvalue', label=l_('Returns'), has_arg=False,
+        Field('returnvalue', label=_('Returns'), has_arg=False,
               names=('returns', 'return')),
-        Field('yieldvalue', label=l_('Yields'), has_arg=False,
+        Field('yieldvalue', label=_('Yields'), has_arg=False,
               names=('yields', 'yield')),
-        Field('returntype', label=l_('Return type'), has_arg=False,
+        Field('returntype', label=_('Return type'), has_arg=False,
               names=('rtype',)),
-        Field('yieldtype', label=l_('Yield type'), has_arg=False,
+        Field('yieldtype', label=_('Yield type'), has_arg=False,
               names=('ytype',)),
-        GroupedField('errorhandling', label=l_('Throws'),
+        GroupedField('errorhandling', label=_('Throws'),
                      names=('throw', 'throws'), can_collapse=True),
     ]
 
@@ -631,8 +631,8 @@ class ChapelModuleIndex(Index):
     """Provides Chapel module index based on chpl:module."""
 
     name = 'modindex'
-    localname = l_('Chapel Module Index')
-    shortname = l_('modules')
+    localname = _('Chapel Module Index')
+    shortname = _('modules')
 
     def generate(self, docnames=None):
         """Returns entries for index given by ``name``. If ``docnames`` is given,
@@ -738,17 +738,17 @@ class ChapelDomain(Domain):
     labels = 'Chapel'
 
     object_types = {
-        'data': ObjType(l_('data'), 'data', 'const', 'var', 'param', 'type'),
-        'type': ObjType(l_('type'), 'type', 'data'),
-        'function': ObjType(l_('function'), 'func', 'proc'),
-        'iterfunction': ObjType(l_('iterfunction'), 'func', 'iter', 'proc'),
-        'enum': ObjType(l_('enum'), 'enum'),
-        'class': ObjType(l_('class'), 'class'),
-        'record': ObjType(l_('record'), 'record'),
-        'method': ObjType(l_('method'), 'meth', 'proc'),
-        'itermethod': ObjType(l_('itermethod'), 'meth', 'iter'),
-        'attribute': ObjType(l_('attribute'), 'attr'),
-        'module': ObjType(l_('module'), 'mod'),
+        'data': ObjType(_('data'), 'data', 'const', 'var', 'param', 'type'),
+        'type': ObjType(_('type'), 'type', 'data'),
+        'function': ObjType(_('function'), 'func', 'proc'),
+        'iterfunction': ObjType(_('iterfunction'), 'func', 'iter', 'proc'),
+        'enum': ObjType(_('enum'), 'enum'),
+        'class': ObjType(_('class'), 'class'),
+        'record': ObjType(_('record'), 'record'),
+        'method': ObjType(_('method'), 'meth', 'proc'),
+        'itermethod': ObjType(_('itermethod'), 'meth', 'iter'),
+        'attribute': ObjType(_('attribute'), 'attr'),
+        'module': ObjType(_('module'), 'mod'),
     }
 
     directives = {
@@ -794,7 +794,7 @@ class ChapelDomain(Domain):
         'objects': {},   # fullname -> docname, objtype
         'modules': {},   # modname -> docname, synopsis, platform, deprecated
         'labels': {      # labelname -> docname, labelid, sectionname
-            'chplmodindex': ('chpl-modindex', '', l_('Chapel Module Index')),
+            'chplmodindex': ('chpl-modindex', '', _('Chapel Module Index')),
         },
         'anonlabels': {  # labelname -> docname, labelid
             'chplmodindex': ('chpl-modindex', ''),

--- a/util/release.bash
+++ b/util/release.bash
@@ -27,13 +27,13 @@ fi
 echo "Version number is: ${version}"
 
 echo "Ensuring requirements are up-to-date..."
-pip install -r requirements.txt -r test-requirements.txt -r docs-requirements.txt
+python3 -m pip install -r requirements.txt -r test-requirements.txt -r docs-requirements.txt
 
 echo "Ensuring package is installed..."
 python setup.py develop
 
 echo "Running tox..."
-tox -e py26,py27,py34,flake8,coverage,docs,doc-test
+tox -e py36,flake8,coverage,docs,doc-test
 
 sha1=$(git rev-parse HEAD)
 echo "Tagging latest sha1 (${sha1}) as version ${version}"
@@ -46,6 +46,6 @@ echo "Cleaning repo..."
 git clean -dxf
 
 echo "Building and uploading python package to pypi..."
-python setup.py sdist upload
+python3 setup.py sdist upload
 
 echo "Version ${version} is released."


### PR DESCRIPTION
We want to drop support for Python 2 and start taking advantage of later features
of Sphinx, or at the very least not be unreasonably far behind on Sphinx.

Update our Sphinx version from 1.8.5 to 3.2.1.  We've been on 1.8.5 for a while,
in part due to not being ready to switch to Python 3 full time.  Now that we want
to start relying on Python 3, update the version of Sphinx we use.

As part of this change, replace uses of `sphinx.locale.l_` with `sphinx.locale._`.
`l_` was deprecated and ultimately removed.  The deprecation message says to use
`_` instead, so do that.

Updates Travis to use 3.6 to test instead of 2.7 and 3.4.  Also updates setup.py and
the release script to use Python 3 as well, and for the new updates to the installation
requirements.  Everything should be tested except for the release script, which I was
worried would prematurely tag the release.

This change additionally migrates to using `python3 -m pip` instead of `pip` to
install packages, since pip is included in later python releases.  These changes were
originally performed by Michael on the main Chapel repo copy of this repository.