### PR TITLE
Fix release script

### DIFF
--- a/sphinxcontrib/chapeldomain/__init__.py
+++ b/sphinxcontrib/chapeldomain/__init__.py
@@ -30,7 +30,7 @@ from sphinx.util.docfields import Field, GroupedField, TypedField
 from sphinx.util.nodes import make_refnode
 
 
-VERSION = '0.0.15'
+VERSION = '0.0.18'
 
 
 # regex for parsing proc, iter, class, record, etc.

--- a/util/release.bash
+++ b/util/release.bash
@@ -28,6 +28,7 @@ echo "Version number is: ${version}"
 
 echo "Ensuring requirements are up-to-date..."
 python3 -m pip install -r requirements.txt -r test-requirements.txt -r docs-requirements.txt
+python3 -m pip install twine wheel
 
 echo "Ensuring package is installed..."
 python setup.py develop
@@ -46,6 +47,7 @@ echo "Cleaning repo..."
 git clean -dxf
 
 echo "Building and uploading python package to pypi..."
-python3 setup.py sdist upload
+python3 setup.py sdist bdist_wheel
+twine upload dist/*
 
 echo "Version ${version} is released."


### PR DESCRIPTION
Using setup.py's upload command is not the preferred way to upload to pypi now,
we need to use twine.  So update the script to install twine and wheel, and use
the commands twine expects in order to upload to pypi.

There may also be an issue with uploading via the script for authentication
purposes?  Either that or I typed my password wrong when I ran it through the
script.

Also update the release version so that we're ready whenever the next release
ends up being.

----
Signed-off-by: Lydia Duncan <lydia-duncan@users.noreply.github.com>