### PR TITLE
Improve the custom pygments lexer

### DIFF
--- a/sphinxcontrib/chapeldomain/chapel.py
+++ b/sphinxcontrib/chapeldomain/chapel.py
@@ -27,36 +27,36 @@ class ChapelLexer(RegexLexer):
     aliases = ['chapel', 'chpl']
     # mimetypes = ['text/x-chapel']
 
-    known_types = ( 'bool', 'bytes', 'complex', 'locale', 'imag', 'int',
-                    'nothing', 'opaque', 'range', 'real', 'string', 'uint',
-                    'void' )
+    known_types = ('bool', 'bytes', 'complex', 'locale', 'imag', 'int',
+                   'nothing', 'opaque', 'range', 'real', 'string', 'uint',
+                   'void')
 
-    type_modifiers = ( 'atomic', 'single', 'sync',
-                       'borrowed', 'owned', 'shared', 'unmanaged' )
+    type_modifiers = ('atomic', 'single', 'sync',
+                      'borrowed', 'owned', 'shared', 'unmanaged')
 
-    declarations = ( 'config', 'const', 'in', 'inout', 'out', 'param', 'ref',
-                     'type', 'var' )
+    declarations = ('config', 'const', 'in', 'inout', 'out', 'param', 'ref',
+                    'type', 'var')
 
-    constants = ( 'false', 'nil', 'none', 'true' )
+    constants = ('false', 'nil', 'none', 'true')
 
-    other_keywords = ( 'align', 'as',
-                       'begin', 'break', 'by',
-                       'catch', 'cobegin', 'coforall', 'continue',
-                       'defer', 'delete', 'dmapped', 'do', 'domain',
-                       'else', 'enum', 'except', 'export', 'extern',
-                       'for', 'forall', 'forwarding',
-                       'if', 'import', 'index', 'init', 'inline',
-                       'label', 'lambda', 'let', 'lifetime', 'local',
-                       'new', 'noinit',
-                       'on', 'only', 'otherwise', 'override',
-                       'pragma', 'private', 'prototype', 'public',
-                       'reduce', 'require', 'return',
-                       'scan', 'select', 'serial', 'sparse', 'subdomain',
-                       'then', 'this', 'throw', 'throws', 'try',
-                       'use',
-                       'when', 'where', 'while', 'with',
-                       'yield',
-                       'zip' )
+    other_keywords = ('align', 'as',
+                      'begin', 'break', 'by',
+                      'catch', 'cobegin', 'coforall', 'continue',
+                      'defer', 'delete', 'dmapped', 'do', 'domain',
+                      'else', 'enum', 'except', 'export', 'extern',
+                      'for', 'forall', 'forwarding',
+                      'if', 'import', 'index', 'init', 'inline',
+                      'label', 'lambda', 'let', 'lifetime', 'local',
+                      'new', 'noinit',
+                      'on', 'only', 'otherwise', 'override',
+                      'pragma', 'private', 'prototype', 'public',
+                      'reduce', 'require', 'return',
+                      'scan', 'select', 'serial', 'sparse', 'subdomain',
+                      'then', 'this', 'throw', 'throws', 'try',
+                      'use',
+                      'when', 'where', 'while', 'with',
+                      'yield',
+                      'zip')
 
     tokens = {
         'root': [

--- a/sphinxcontrib/chapeldomain/chapel.py
+++ b/sphinxcontrib/chapeldomain/chapel.py
@@ -27,12 +27,13 @@ class ChapelLexer(RegexLexer):
     aliases = ['chapel', 'chpl']
     # mimetypes = ['text/x-chapel']
 
-    known_types = ('bool', 'bytes', 'complex', 'locale', 'imag', 'int',
+    known_types = ('bool', 'bytes', 'complex', 'imag', 'int', 'locale',
                    'nothing', 'opaque', 'range', 'real', 'string', 'uint',
                    'void')
 
-    type_modifiers = ('atomic', 'single', 'sync',
-                      'borrowed', 'owned', 'shared', 'unmanaged')
+    type_modifiers_par = ('atomic', 'single', 'sync')
+    type_modifiers_mem = ('borrowed', 'owned', 'shared', 'unmanaged')
+    type_modifiers = (*type_modifiers_par, *type_modifiers_mem)
 
     declarations = ('config', 'const', 'in', 'inout', 'out', 'param', 'ref',
                     'type', 'var')

--- a/sphinxcontrib/chapeldomain/chapel.py
+++ b/sphinxcontrib/chapeldomain/chapel.py
@@ -27,6 +27,37 @@ class ChapelLexer(RegexLexer):
     aliases = ['chapel', 'chpl']
     # mimetypes = ['text/x-chapel']
 
+    known_types = ( 'bool', 'bytes', 'complex', 'locale', 'imag', 'int',
+                    'nothing', 'opaque', 'range', 'real', 'string', 'uint',
+                    'void' )
+
+    type_modifiers = ( 'atomic', 'single', 'sync',
+                       'borrowed', 'owned', 'shared', 'unmanaged' )
+
+    declarations = ( 'config', 'const', 'in', 'inout', 'out', 'param', 'ref',
+                     'type', 'var' )
+
+    constants = ( 'false', 'nil', 'none', 'true' )
+
+    other_keywords = ( 'align', 'as',
+                       'begin', 'break', 'by',
+                       'catch', 'cobegin', 'coforall', 'continue',
+                       'defer', 'delete', 'dmapped', 'do', 'domain',
+                       'else', 'enum', 'except', 'export', 'extern',
+                       'for', 'forall', 'forwarding',
+                       'if', 'import', 'index', 'init', 'inline',
+                       'label', 'lambda', 'let', 'lifetime', 'local',
+                       'new', 'noinit',
+                       'on', 'only', 'otherwise', 'override',
+                       'pragma', 'private', 'prototype', 'public',
+                       'reduce', 'require', 'return',
+                       'scan', 'select', 'serial', 'sparse', 'subdomain',
+                       'then', 'this', 'throw', 'throws', 'try',
+                       'use',
+                       'when', 'where', 'while', 'with',
+                       'yield',
+                       'zip' )
+
     tokens = {
         'root': [
             (r'\n', Text),
@@ -36,34 +67,11 @@ class ChapelLexer(RegexLexer):
             (r'//(.*?)\n', Comment.Single),
             (r'/(\\\n)?[*](.|\n)*?[*](\\\n)?/', Comment.Multiline),
 
-            (r'(config|const|in|inout|out|param|ref|type|var)\b',
-             Keyword.Declaration),
-            (r'(false|nil|none|true)\b', Keyword.Constant),
-            (words(('bool', 'bytes', 'complex', 'imag', 'int', 'nothing',
-                   'opaque', 'range', 'real', 'string', 'uint', 'void'),
-                   suffix=r'\b'),
-             Keyword.Type),
-            (words((
-                'align', 'as', 'atomic',
-                'begin', 'borrowed', 'break', 'by',
-                'catch', 'cobegin', 'coforall', 'continue',
-                'defer', 'delete', 'dmapped', 'do', 'domain',
-                'else', 'enum', 'except', 'export', 'extern',
-                'for', 'forall', 'forwarding',
-                'if', 'import', 'index', 'init', 'inline',
-                'label', 'lambda', 'let', 'lifetime', 'local', 'locale'
-                'new', 'noinit',
-                'on', 'only', 'otherwise', 'override', 'owned',
-                'pragma', 'private', 'prototype', 'public',
-                'reduce', 'require', 'return',
-                'scan', 'select', 'serial', 'shared', 'single', 'sparse',
-                'subdomain', 'sync',
-                'then', 'this', 'throw', 'throws', 'try',
-                'unmanaged', 'use',
-                'when', 'where', 'while', 'with',
-                'yield',
-                'zip'), suffix=r'\b'),
-             Keyword),
+            (words(declarations, suffix=r'\b'), Keyword.Declaration),
+            (words(constants, suffix=r'\b'), Keyword.Constant),
+            (words(known_types, suffix=r'\b'), Keyword.Type),
+            (words((*type_modifiers, *other_keywords), suffix=r'\b'), Keyword),
+
             (r'(iter)((?:\s)+)', bygroups(Keyword, Text), 'procname'),
             (r'(proc)((?:\s)+)', bygroups(Keyword, Text), 'procname'),
             (r'(class|module|record|union)(\s+)', bygroups(Keyword, Text),
@@ -109,7 +117,18 @@ class ChapelLexer(RegexLexer):
             (r'[a-zA-Z_][\w$]*', Name.Class, '#pop'),
         ],
         'procname': [
-            (r'([a-zA-Z_][.\w$]*|\~[a-zA-Z_][.\w$]*|[+*/!~%<>=&^|\-]{1,2})',
+            (r'([a-zA-Z_][.\w$]*|'    # regular function name, including 2ndary
+             r'\~[a-zA-Z_][.\w$]*|'   # support for legacy destructors?
+             r'[+*/!~%<>=&^|\-]{1,2})',  # operators
              Name.Function, '#pop'),
+
+            # allow `proc (atomic T).foo`
+            (r'\(', Punctuation, "receivertype"),
+            (r'\)+\.', Punctuation),
+        ],
+        'receivertype': [
+            (words(type_modifiers, suffix=r'\b'), Keyword),
+            (words(known_types, suffix=r'\b'), Keyword.Type),
+            (r'[^()]*', Name.Other, '#pop'),
         ],
     }


### PR DESCRIPTION
This PR:

- Refactors large tuples into their own variables
- Adds a new `receivertype` state to handle
<img width="553" alt="Screen Shot 2020-11-19 at 10 00 25 AM" src="https://user-images.githubusercontent.com/4141670/99705104-2581a080-2a4e-11eb-8727-957097d03e6a.png">

by properly highlighting it including the keywords within parentheses:

<img width="540" alt="Screen Shot 2020-11-19 at 10 00 44 AM" src="https://user-images.githubusercontent.com/4141670/99705166-3500e980-2a4e-11eb-9407-3e18ac2c3ce3.png">

We can tweak how we handle secondary methods better, but this PR doesn't do that. For example we can't currently higlight without this patch:

<img width="606" alt="Screen Shot 2020-11-19 at 10 03 54 AM" src="https://user-images.githubusercontent.com/4141670/99705429-9032dc00-2a4e-11eb-9379-fcd615efe7c9.png">

With this patch, we can highlight, but a non-parenthesized receiver type shouldn't be higlighted as function name
<img width="583" alt="Screen Shot 2020-11-19 at 10 05 06 AM" src="https://user-images.githubusercontent.com/4141670/99705563-bfe1e400-2a4e-11eb-88ea-27274f2a0420.png">

I wasn't able to get that puzzle solved in a reasonable amount of time, but I think this is still progress. At least we don't have to workaround this issue when writing `code-block`s in docs.

