### PR TITLE
Pass the class to add_lexer instead of instance

### DIFF
--- a/sphinxcontrib/chapeldomain/__init__.py
+++ b/sphinxcontrib/chapeldomain/__init__.py
@@ -1029,6 +1029,6 @@ class ChapelDomain(Domain):
 def setup(app):
     """Add Chapel domain to Sphinx app."""
     # First add the in-house lexer to override the pygments one
-    app.add_lexer('chapel', ChapelLexer())
+    app.add_lexer('chapel', ChapelLexer)
     app.add_config_value('chapeldomain_modindex_common_prefix', [], 'html')
     app.add_domain(ChapelDomain)


### PR DESCRIPTION
Creating an instance of the lexer and passing it to add_lexer is deprecated in Sphinx and generates warnings. This PR passes the type instead.