### PR TITLE
Fix problem: dictionary changed size during iteration

### DIFF
--- a/sphinxcontrib/chapeldomain/__init__.py
+++ b/sphinxcontrib/chapeldomain/__init__.py
@@ -808,28 +808,28 @@ class ChapelDomain(Domain):
 
     def clear_doc(self, docname):
         """Remove the data associated with this instance of the domain."""
-        todel = [ ]
+        todel = []
         for fullname, (fn, x) in self.data['objects'].items():
             if fn == docname:
                 todel.append(fullname)
         for fullname in todel:
             del self.data['objects'][fullname]
 
-        todel = [ ]
+        todel = []
         for modname, (fn, x, x, x) in self.data['modules'].items():
             if fn == docname:
                 todel.append(modname)
         for modname in todel:
             del self.data['modules'][modname]
 
-        todel = [ ]
+        todel = []
         for labelname, (fn, x, x) in self.data['labels'].items():
             if fn == docname:
                 todel.append(labelname)
         for labelname in todel:
             del self.data['labels'][labelname]
 
-        todel = [ ]
+        todel = []
         for anonlabelname, (fn, x) in self.data['anonlabels'].items():
             if fn == docname:
                 todel.append(anonlabelname)

--- a/sphinxcontrib/chapeldomain/__init__.py
+++ b/sphinxcontrib/chapeldomain/__init__.py
@@ -808,18 +808,33 @@ class ChapelDomain(Domain):
 
     def clear_doc(self, docname):
         """Remove the data associated with this instance of the domain."""
+        todel = [ ]
         for fullname, (fn, x) in self.data['objects'].items():
             if fn == docname:
-                del self.data['objects'][fullname]
+                todel.append(fullname)
+        for fullname in todel:
+            del self.data['objects'][fullname]
+
+        todel = [ ]
         for modname, (fn, x, x, x) in self.data['modules'].items():
             if fn == docname:
-                del self.data['modules'][modname]
+                todel.append(modname)
+        for modname in todel:
+            del self.data['modules'][modname]
+
+        todel = [ ]
         for labelname, (fn, x, x) in self.data['labels'].items():
             if fn == docname:
-                del self.data['labels'][labelname]
+                todel.append(labelname)
+        for labelname in todel:
+            del self.data['labels'][labelname]
+
+        todel = [ ]
         for anonlabelname, (fn, x) in self.data['anonlabels'].items():
             if fn == docname:
-                del self.data['anonlabels'][anonlabelname]
+                todel.append(anonlabelname)
+        for anonlabelname in todel:
+            del self.data['anonlabels'][anonlabelname]
 
     def find_obj(self, env, modname, classname, name, type_name, searchmode=0):
         """Find a Chapel object for "name", possibly with module or class/record


### PR DESCRIPTION
The issue comes up when using sphinx to do an incremental
docs build (see https://github.com/chapel-lang/chapel/pull/16835 )

I encountered an error along these lines:
```
Exception occurred:
  File "CHPL_HOME/third-party/chpl-venv/install/chpldeps/sphinxcontrib/chapeldomain/__init__.py", line 810, in clear_doc
    for fullname, (fn, x) in self.data['objects'].items():
RuntimeError: dictionary changed size during iteration
The full traceback has been saved in /var/folders/b6/1lwlz22n5d53878_x52vp3kr0007pg/T/sphinx-err-xabz0j9_.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
A bug report can be filed in the tracker at <https://github.com/sphinx-doc/sphinx/issues>. Thanks!
```

To fix, this PR adjusts `clear_doc` to save the keys to remove in a list and then remove them.

Reviewed by @lydia-duncan - thanks!