### PR TITLE
Add new keywords and : operator to the pygments lexer

### DIFF
--- a/sphinxcontrib/chapeldomain/chapel.py
+++ b/sphinxcontrib/chapeldomain/chapel.py
@@ -76,8 +76,9 @@ class ChapelLexer(RegexLexer):
             (r'(iter)((?:\s)+)', bygroups(Keyword, Text), 'procname'),
             (r'(proc)((?:\s)+)', bygroups(Keyword, Text), 'procname'),
             (r'(operator)((?:\s)+)', bygroups(Keyword, Text), 'procname'),
-            (r'(class|interface|module|record|union)(\s+)', bygroups(Keyword, Text),
-             'classname'),
+            (r'(class|interface|module|record|union)(\s+)',
+                bygroups(Keyword, Text),
+                'classname'),
 
             # imaginary integers
             (r'\d+i', Number),

--- a/sphinxcontrib/chapeldomain/chapel.py
+++ b/sphinxcontrib/chapeldomain/chapel.py
@@ -5,7 +5,7 @@
 
     Lexer for the Chapel language.
 
-    :copyright: Copyright 2006-2020 by the Pygments team, Thomas van Doren
+    :copyright: Copyright 2006-2021 by the Pygments team, Thomas van Doren
     :license: BSD, see LICENSE for details.
 """
 

--- a/sphinxcontrib/chapeldomain/chapel.py
+++ b/sphinxcontrib/chapeldomain/chapel.py
@@ -50,7 +50,7 @@ class ChapelLexer(RegexLexer):
                       'label', 'lambda', 'let', 'lifetime', 'local',
                       'new', 'noinit',
                       'on', 'only', 'otherwise', 'override',
-                      'pragma', 'private', 'prototype', 'public',
+                      'pragma', 'primitive', 'private', 'prototype', 'public',
                       'reduce', 'require', 'return',
                       'scan', 'select', 'serial', 'sparse', 'subdomain',
                       'then', 'this', 'throw', 'throws', 'try',

--- a/sphinxcontrib/chapeldomain/chapel.py
+++ b/sphinxcontrib/chapeldomain/chapel.py
@@ -45,8 +45,8 @@ class ChapelLexer(RegexLexer):
                       'catch', 'cobegin', 'coforall', 'continue',
                       'defer', 'delete', 'dmapped', 'do', 'domain',
                       'else', 'enum', 'except', 'export', 'extern',
-                      'for', 'forall', 'forwarding',
-                      'if', 'import', 'index', 'init', 'inline',
+                      'for', 'forall', 'foreach', 'forwarding',
+                      'if', 'implements', 'import', 'index', 'init', 'inline',
                       'label', 'lambda', 'let', 'lifetime', 'local',
                       'new', 'noinit',
                       'on', 'only', 'otherwise', 'override',
@@ -75,7 +75,8 @@ class ChapelLexer(RegexLexer):
 
             (r'(iter)((?:\s)+)', bygroups(Keyword, Text), 'procname'),
             (r'(proc)((?:\s)+)', bygroups(Keyword, Text), 'procname'),
-            (r'(class|module|record|union)(\s+)', bygroups(Keyword, Text),
+            (r'(operator)((?:\s)+)', bygroups(Keyword, Text), 'procname'),
+            (r'(class|interface|module|record|union)(\s+)', bygroups(Keyword, Text),
              'classname'),
 
             # imaginary integers
@@ -120,7 +121,7 @@ class ChapelLexer(RegexLexer):
         'procname': [
             (r'([a-zA-Z_][.\w$]*|'    # regular function name, including 2ndary
              r'\~[a-zA-Z_][.\w$]*|'   # support for legacy destructors?
-             r'[+*/!~%<>=&^|\-]{1,2})',  # operators
+             r'[+*/!~%<>=&^|\-:]{1,2})',  # operators
              Name.Function, '#pop'),
 
             # allow `proc (atomic T).foo`


### PR DESCRIPTION
The new keywords in Chapel 1.24: `operator`, `foreach`, `implements`, `interface`
We also accept `:` as operator, now.

While there, also adds `primitive` as a keyword to the lexer.