### PR TITLE
Switch from nosetest to pytest

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,18 +14,28 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.6"
+        python-version: "3.10"
+
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        python -m pip install -r requirements.txt -r test-requirements.txt -r docs-requirements.txt
+        python3 -m pip install --upgrade pip
+        python3 -m pip install tox
+
     - name: Lint
-      run: flake8 sphinxcontrib/
+      run: |
+        python3 -m tox -e flake8
+
     - name: Test
-      run: nosetests --verbose --with-cov --cov-report xml --cover-package=sphinxcontrib.chapeldomain
+      run: |
+        python3 -m tox -e py
+
     - name: Make docs
       run: |
-        ( export PYTHONPATH=`pwd` && cd docs/ && make html )
-        ( export PYTHONPATH=`pwd` && cd doc-test/ && make html )
-    - name: Codecode
+        python3 -m tox -e docs,doc-test
+
+    - name: Coverage
+      run: |
+        python3 -m tox -e coverage
+
+    - name: Upload codecov
       uses: codecov/codecov-action@v2

--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,7 @@ htmlcov/
 .tox/
 .coverage
 .cache
-nosetests.xml
+results.xml
 coverage.xml
 
 # Translations

--- a/docs/developers.rst
+++ b/docs/developers.rst
@@ -32,7 +32,7 @@ a local workstation, tox_ can be used to run the tests in a similar fashion.
 
 .. code-block:: bash
 
-    tox              # run unittests with py27, py34
+    tox              # run unittests with py310
     tox -e flake8    # flake8 source code checker
     tox -e coverage  # run code coverage analysis
     tox -e docs      # verify the docs build

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,6 @@
 flake8
 mock
-nose
-nose-cov
+pytest
+pytest-cov
 tox
 unittest2

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,16 @@
 [tox]
-envlist = py27,py34
+envlist = py310
 
 [testenv]
 deps =
     -rrequirements.txt
     -rtest-requirements.txt
     -rdocs-requirements.txt
-commands = nosetests --verbose
 allowlist_externals = make
+commands = pytest --verbose
 
 [testenv:coverage]
-commands = nosetests --verbose --with-xunit --with-cov --cov-report xml --cov-report html --cover-package=sphinxcontrib.chapeldomain
+commands = pytest --verbose --junitxml=results.xml --cov-report xml --cov-report html --cov=sphinxcontrib.chapeldomain
 
 [testenv:flake8]
 commands = flake8 {toxinidir}/sphinxcontrib


### PR DESCRIPTION
nosetest hasn't been updated/supported in years and no longer works with
python 3.9+ (nose-devs/nose 1099). Switch to pytest and upgrade python
versions.

Note that this appears to drop our code coverage from ~60% to ~40%, but
that's because nosetest was including coverage results for the tests
themselves, which isn't particularly helpful anyways.

As part of this, switch CI to call tox to run testing instead of copying
the commands we use.