### PR TITLE
Quiet tox warning about `make` being an unrecognized command

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ deps =
     -rtest-requirements.txt
     -rdocs-requirements.txt
 commands = nosetests --verbose
+allowlist_externals = make
 
 [testenv:coverage]
 commands = nosetests --verbose --with-xunit --with-cov --cov-report xml --cov-report html --cover-package=sphinxcontrib.chapeldomain


### PR DESCRIPTION
We use `make` as part of the tox build, but tox tries to check that any
commands are included in requirements files. For external tools like
`make` you just have to tell tox it's external to avoid the warnings.
For more information see:
https://tox.wiki/en/latest/example/basic.html#allowing-non-virtualenv-commands

Resolves #44