### PR TITLE
Add a github action workflow to upload to PyPI

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,72 @@
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      repository:
+        description: 'Repository'
+        required: true
+        default: 'PYPI'
+        type: choice
+        options:
+        - 'PYPI'
+        - 'TEST_PYPI'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -r test-requirements.txt
+
+    - name: Test package
+      run: |
+        python3 -m pip install -e .
+        pytest --verbose
+
+  deploy:
+    needs: test
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install wheel
+
+    - name: Build package
+      run: |
+        python3 setup.py sdist bdist_wheel
+
+    - name: Publish to PyPI
+      if: ${{ github.event.inputs.repository == 'PYPI' || github.event.inputs.repository == '' }}
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}
+
+    - name: Publish to test PyPI
+      if: ${{ github.event.inputs.repository == 'TEST_PYPI' }}
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/


### PR DESCRIPTION
Previously, we would manually run `util/release.bash` to tag a new
release and upload it to PyPI. This required having local PyPI
credentials and being careful that your branches were all up to date.

This adds a github action to simplify and automate release creation.
When a new release is created (or if manually started) the job will run
testing and if that passes will then create the release and upload it.
We run the test and build/upload steps in separate jobs to ensure we
have a clean environment for the upload. And note that testing manually
installs the package and runs pytest instead of using tox, just to make
sure that things work from a user perspective and there's no
dependencies that are listed in tox, but not setup.py.

By default this will upload to the official pypi repo and authentication
is done with a secret token. To test releases, there is also an option
to upload to test.pypi.