### PR TITLE
feat: add operator directives and op role

### DIFF
--- a/sphinxcontrib/chapeldomain/__init__.py
+++ b/sphinxcontrib/chapeldomain/__init__.py
@@ -35,7 +35,7 @@ from sphinx.util.nodes import make_refnode
 
 from sphinxcontrib.chapeldomain.chapel import ChapelLexer
 
-VERSION = '0.0.24'
+VERSION = '0.0.23'
 
 
 # regex for parsing proc, iter, class, record, etc.

--- a/sphinxcontrib/chapeldomain/__init__.py
+++ b/sphinxcontrib/chapeldomain/__init__.py
@@ -506,19 +506,7 @@ class ChapelClassMember(ChapelObject):
         """Return text for index entry based on object type."""
         name, cls = name_cls
         add_modules = self.env.config.add_module_names
-        if self.objtype == 'opmethod':
-            try:
-                clsname, attrname = name.rsplit('.', 1)
-            except ValueError:
-                if modname:
-                    return _('%s (in module %s)') % (name, modname)
-                else:
-                    return name
-            if modname and add_modules:
-                return _('%s (%s.%s opmethod)') % (attrname, modname, clsname)
-            else:
-                return _('%s (%s opmethod)') % (attrname, clsname)
-        elif self.objtype.endswith('method'):
+        if self.objtype.endswith('method'):
             try:
                 clsname, methname = name.rsplit('.', 1)
             except ValueError:
@@ -609,12 +597,7 @@ class ChapelModuleLevel(ChapelObject):
 
     def get_index_text(self, modname, name_cls):
         """Return text for index entry based on object type."""
-        if self.objtype == 'opfunction':
-            if not modname:
-                return _('%s() (opfunction %s)') % \
-                    (name_cls[0], self.chpl_type_name)
-            return _('%s() (in module %s)') % (name_cls[0], modname)
-        elif self.objtype.endswith('function'):
+        if self.objtype.endswith('function'):
             if not modname:
                 return _('%s() (built-in %s)') % \
                     (name_cls[0], self.chpl_type_name)

--- a/sphinxcontrib/chapeldomain/__init__.py
+++ b/sphinxcontrib/chapeldomain/__init__.py
@@ -494,7 +494,7 @@ class ChapelClassMember(ChapelObject):
 
     def get_signature_prefix(self, sig):
         """Return signature prefix based on sig. May include portion of the sig
-        text, if relevant (e.g. `proc foo()` will return 'proc' here.
+        text, if relevant (e.g. `proc foo()` will return 'proc' here).
         """
         return self._get_sig_prefix(sig)
 
@@ -599,7 +599,7 @@ class ChapelModuleLevel(ChapelObject):
 
     def get_signature_prefix(self, sig):
         """Return signature prefix based on sig. May include portion of the sig
-        text, if relevant (e.g. `proc foo()` will return `proc` here.
+        text, if relevant (e.g. `proc foo()` will return `proc` here).
         """
         return self._get_sig_prefix(sig)
 
@@ -677,7 +677,7 @@ class ChapelModuleIndex(Index):
         """Returns entries for index given by ``name``. If ``docnames`` is
         given, restrict to entries referring to these docnames.
 
-        Retunrs tuple of ``(content, collapse)``. ``collapse`` is bool. When
+        Returns tuple of ``(content, collapse)``. ``collapse`` is bool. When
         True, sub-entries should start collapsed for output formats that
         support collapsing.
 

--- a/test/test_chapeldomain.py
+++ b/test/test_chapeldomain.py
@@ -309,6 +309,23 @@ class ChapelClassMemberTests(ChapelObjectTestCase):
             mod = self.new_obj(objtype)
             self.assertEqual(expected, mod.needs_arglist())
 
+    def test_chpl_type_name(self):
+        """Verify chpl_type_name property for different objtypes."""
+        test_cases = [
+            ('function', ''),
+            ('iterfunction', ''),
+            ('type', ''),
+            ('data', ''),
+            ('attribute', ''),
+            ('method', 'method'),
+            ('itermethod', 'iterator'),
+            ('opfunction', ''),
+            ('opmethod', 'operator'),
+        ]
+        for objtype, expected_type in test_cases:
+            mod = self.new_obj(objtype)
+            self.assertEqual(expected_type, mod.chpl_type_name)
+
 
 class ChapelObjectTests(ChapelObjectTestCase):
     """ChapelObject tests."""


### PR DESCRIPTION
This PR adds two directives for `operators`. One of `opfunction` or 
`opmethod` will be chosen depending on if the `operator` is defined at the
module level or inside a record/class. 

It also adds a single new role for operators, `op`, which can be used in the
`rst` docs to link to previously defined `opfunction` or `opmethod` entries.

A few tests were also added to verify the new directives were functioning
as intended. 

TESTING:

- [x] all included `UnitTest` tests pass
- [x] can generate Chapel docs with production `chpldoc`
- [x] can generate Chapel docs with `dyno-chpldoc`

reviewed by @lydia-duncan - thanks!

Signed-off-by: arezaii <ahmad.rezaii@hpe.com>