### PR TITLE
Pin Flake8 version and update Sphinx version to match main chapel repo

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 docutils==0.16
-Sphinx==4.3.2
+Sphinx==4.5.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-flake8
+flake8==5.0.4
 mock
 pytest
 pytest-cov


### PR DESCRIPTION
We ran into some problems earlier because flake8 updated underneath us and was
detecting more issues.  This pins flake8 to the most recent version so that we
update it on our terms in the future

----
Signed-off-by: Lydia Duncan <lydia-duncan@users.noreply.github.com>