### PR TITLE
Update setuptools used versions and set pytest to more recent version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,8 +41,8 @@ setup(
     packages=find_packages(exclude=('test',)),
     include_package_data=True,
     install_requires=[
-        'docutils',
-        'Sphinx',
+        'docutils==0.16',
+        'Sphinx==4.5.0',
     ],
     namespace_packages=['sphinxcontrib']
 )

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,5 @@
 flake8==5.0.4
 mock
-pytest==7.1.1
+pytest==7.1.2
 pytest-cov
 tox


### PR DESCRIPTION
Looks like the problem is coming from more recent versions of packages that we
pin for our requirements files.  setuptools doesn't use the requirements files
to install dependencies, so it needs the limits as well.

While there, since the problem didn't seem to be pytest, pin pytest to the more
recent version

----
Signed-off-by: Lydia Duncan <lydia-duncan@users.noreply.github.com>