### PR TITLE
Update the version and add a note to the requirements file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+# Note: DON'T UPDATE THIS WITHOUT ALSO UPDATING SETUP.PY
 docutils==0.16
 Sphinx==4.5.0

--- a/sphinxcontrib/chapeldomain/__init__.py
+++ b/sphinxcontrib/chapeldomain/__init__.py
@@ -35,7 +35,7 @@ from sphinx.util.nodes import make_refnode
 
 from sphinxcontrib.chapeldomain.chapel import ChapelLexer
 
-VERSION = '0.0.23'
+VERSION = '0.0.24'
 
 
 # regex for parsing proc, iter, class, record, etc.


### PR DESCRIPTION
The version update is the usual post-release version bump so that we are ready
for the next one.

The requirements file note is so that we don't forget to update setup.py the
next time we update the requirements.txt file.  We had previously removed the
version numbers from setup.py under the mistaken belief that setting it in the
requirements file was sufficient to affect what was used when calling setup.py.
However, that was not the case in the independent release job, so it needed the
version numbers restored

----
Signed-off-by: Lydia Duncan <lydia-duncan@users.noreply.github.com>