### PR TITLE
add support for lexing attributes

### DIFF
--- a/sphinxcontrib/chapeldomain/chapel.py
+++ b/sphinxcontrib/chapeldomain/chapel.py
@@ -73,7 +73,7 @@ class ChapelLexer(RegexLexer):
             (words(known_types, suffix=r'\b'), Keyword.Type),
             (words((*type_modifiers, *other_keywords), suffix=r'\b'), Keyword),
 
-            (r'(@)', Keyword, 'attributename'),
+            (r'@', Keyword, 'attributename'),
             (r'(iter)((?:\s)+)', bygroups(Keyword, Text), 'procname'),
             (r'(proc)((?:\s)+)', bygroups(Keyword, Text), 'procname'),
             (r'(operator)((?:\s)+)', bygroups(Keyword, Text), 'procname'),
@@ -136,6 +136,6 @@ class ChapelLexer(RegexLexer):
             (r'[^()]*', Name.Other, '#pop'),
         ],
         'attributename': [
-            (r'([a-zA-Z_][.\w$]*)', Name.Decorator, '#pop'),
+            (r'[a-zA-Z_][.\w$]*', Name.Decorator, '#pop'),
         ],
     }

--- a/sphinxcontrib/chapeldomain/chapel.py
+++ b/sphinxcontrib/chapeldomain/chapel.py
@@ -73,6 +73,7 @@ class ChapelLexer(RegexLexer):
             (words(known_types, suffix=r'\b'), Keyword.Type),
             (words((*type_modifiers, *other_keywords), suffix=r'\b'), Keyword),
 
+            (r'(@)', Keyword, 'attributename'),
             (r'(iter)((?:\s)+)', bygroups(Keyword, Text), 'procname'),
             (r'(proc)((?:\s)+)', bygroups(Keyword, Text), 'procname'),
             (r'(operator)((?:\s)+)', bygroups(Keyword, Text), 'procname'),
@@ -133,5 +134,8 @@ class ChapelLexer(RegexLexer):
             (words(type_modifiers, suffix=r'\b'), Keyword),
             (words(known_types, suffix=r'\b'), Keyword.Type),
             (r'[^()]*', Name.Other, '#pop'),
+        ],
+        'attributename': [
+            (r'([a-zA-Z_][.\w$]*)', Name.Decorator, '#pop'),
         ],
     }


### PR DESCRIPTION
This PR adds support for lexing attributes as added in Chapel https://github.com/chapel-lang/chapel/pull/21425.

This should be merged after the Chapel 1.30 release. Once merged, update the [`Attributes.rst`](https://github.com/chapel-lang/chapel/pull/21886) doc such that example code-blocks are of type `chapel` rather than `text`, 
