### PR TITLE
Generate enum constant Documentation

### DIFF
--- a/sphinxcontrib/chapeldomain/__init__.py
+++ b/sphinxcontrib/chapeldomain/__init__.py
@@ -238,7 +238,7 @@ class ChapelObject(ObjectDescription):
     def _is_attr_like(self):
         """Returns True when objtype is attribute or data."""
         return self.objtype in ('attribute', 'data',
-                                'type', 'enum', 'enumelement')
+                                'type', 'enum', 'enumconstant')
 
     def _is_proc_like(self):
         """Returns True when objtype is *function or *method."""
@@ -505,8 +505,8 @@ class ChapelClassMember(ChapelObject):
             return 'method'
         elif self.objtype == 'opmethod':
             return 'operator'
-        elif self.objtype == 'enum-element':
-            return 'enum element'
+        elif self.objtype == 'enum-constant':
+            return 'enum constant'
         else:
             return ''
 
@@ -783,7 +783,7 @@ class ChapelDomain(Domain):
         'function': ObjType(_('function'), 'func', 'proc'),
         'iterfunction': ObjType(_('iterfunction'), 'func', 'iter', 'proc'),
         'enum': ObjType(_('enum'), 'enum'),
-        'enumelement': ObjType(_('enumelement'), 'enumelement'),
+        'enumconstant': ObjType(_('enumconstant'), 'enumconstant'),
         'class': ObjType(_('class'), 'class'),
         'record': ObjType(_('record'), 'record'),
         'method': ObjType(_('method'), 'meth', 'proc'),
@@ -804,7 +804,7 @@ class ChapelDomain(Domain):
         'class': ChapelClassObject,
         'record': ChapelClassObject,
         'enum': ChapelClassObject,
-        'enumelement': ChapelClassMember,
+        'enumconstant': ChapelClassMember,
         'method': ChapelClassMember,
         'opmethod': ChapelClassMember,
         'itermethod': ChapelClassMember,
@@ -825,7 +825,7 @@ class ChapelDomain(Domain):
         'class': ChapelXRefRole(),
         'record': ChapelXRefRole(),
         'enum': ChapelXRefRole(),
-        'enumelement': ChapelXRefRole(),
+        'enumconstant': ChapelXRefRole(),
         'meth': ChapelXRefRole(),
         'attr': ChapelXRefRole(),
         'mod': ChapelXRefRole(),

--- a/sphinxcontrib/chapeldomain/__init__.py
+++ b/sphinxcontrib/chapeldomain/__init__.py
@@ -505,7 +505,7 @@ class ChapelClassMember(ChapelObject):
             return 'method'
         elif self.objtype == 'opmethod':
             return 'operator'
-        elif self.objtype == 'enum-constant':
+        elif self.objtype == 'enumconstant':
             return 'enum constant'
         else:
             return ''

--- a/sphinxcontrib/chapeldomain/__init__.py
+++ b/sphinxcontrib/chapeldomain/__init__.py
@@ -35,7 +35,7 @@ from sphinx.util.nodes import make_refnode
 
 from sphinxcontrib.chapeldomain.chapel import ChapelLexer
 
-VERSION = '0.0.27'
+VERSION = '0.0.28'
 
 
 # regex for parsing proc, iter, class, record, etc.
@@ -237,7 +237,7 @@ class ChapelObject(ObjectDescription):
 
     def _is_attr_like(self):
         """Returns True when objtype is attribute or data."""
-        return self.objtype in ('attribute', 'data', 'type', 'enum')
+        return self.objtype in ('attribute', 'data', 'type', 'enum', 'enumelement')
 
     def _is_proc_like(self):
         """Returns True when objtype is *function or *method."""
@@ -504,6 +504,8 @@ class ChapelClassMember(ChapelObject):
             return 'method'
         elif self.objtype == 'opmethod':
             return 'operator'
+        elif self.objtype == 'enum-element':
+            return 'enum element'
         else:
             return ''
 
@@ -780,6 +782,7 @@ class ChapelDomain(Domain):
         'function': ObjType(_('function'), 'func', 'proc'),
         'iterfunction': ObjType(_('iterfunction'), 'func', 'iter', 'proc'),
         'enum': ObjType(_('enum'), 'enum'),
+        'enumelement': ObjType(_('enumelement'), 'enumelement'),
         'class': ObjType(_('class'), 'class'),
         'record': ObjType(_('record'), 'record'),
         'method': ObjType(_('method'), 'meth', 'proc'),
@@ -801,7 +804,8 @@ class ChapelDomain(Domain):
         #       becomes an attribute on the class. Then xrefs to each constant
         #       would be possible, plus it would scale to large numbers of
         #       constants. (thomasvandoren, 2015-03-12)
-        'enum': ChapelModuleLevel,
+        'enum': ChapelClassObject,
+        'enumelement': ChapelClassMember,
 
         'class': ChapelClassObject,
         'record': ChapelClassObject,
@@ -825,6 +829,7 @@ class ChapelDomain(Domain):
         'class': ChapelXRefRole(),
         'record': ChapelXRefRole(),
         'enum': ChapelXRefRole(),
+        'enumelement': ChapelXRefRole(),
         'meth': ChapelXRefRole(),
         'attr': ChapelXRefRole(),
         'mod': ChapelXRefRole(),

--- a/sphinxcontrib/chapeldomain/__init__.py
+++ b/sphinxcontrib/chapeldomain/__init__.py
@@ -35,7 +35,7 @@ from sphinx.util.nodes import make_refnode
 
 from sphinxcontrib.chapeldomain.chapel import ChapelLexer
 
-VERSION = '0.0.28'
+VERSION = '0.0.27'
 
 
 # regex for parsing proc, iter, class, record, etc.
@@ -562,7 +562,7 @@ class ChapelClassObject(ChapelObject):
 
     def get_index_text(self, modname, name_cls):
         """Return index entry text based on object type."""
-        if self.objtype in ('class', 'record'):
+        if self.objtype in ('class', 'record', 'enum'):
             if not modname:
                 return _('%s (built-in %s)') % (name_cls[0], self.objtype)
             return _('%s (%s in %s)') % (name_cls[0], self.objtype, modname)
@@ -619,7 +619,7 @@ class ChapelModuleLevel(ChapelObject):
                 return _('%s() (built-in %s)') % \
                     (name_cls[0], self.chpl_type_name)
             return _('%s() (in module %s)') % (name_cls[0], modname)
-        elif self.objtype in ('data', 'type', 'enum'):
+        elif self.objtype in ('data', 'type'):
             if not modname:
                 type_name = self.objtype
                 if type_name == 'data':

--- a/sphinxcontrib/chapeldomain/__init__.py
+++ b/sphinxcontrib/chapeldomain/__init__.py
@@ -800,15 +800,10 @@ class ChapelDomain(Domain):
         'iterfunction': ChapelModuleLevel,
         'opfunction': ChapelModuleLevel,
 
-        # TODO: Consider making enums ChapelClassObject, then each constant
-        #       becomes an attribute on the class. Then xrefs to each constant
-        #       would be possible, plus it would scale to large numbers of
-        #       constants. (thomasvandoren, 2015-03-12)
-        'enum': ChapelClassObject,
-        'enumelement': ChapelClassMember,
-
         'class': ChapelClassObject,
         'record': ChapelClassObject,
+        'enum': ChapelClassObject,
+        'enumelement': ChapelClassMember,
         'method': ChapelClassMember,
         'opmethod': ChapelClassMember,
         'itermethod': ChapelClassMember,

--- a/sphinxcontrib/chapeldomain/__init__.py
+++ b/sphinxcontrib/chapeldomain/__init__.py
@@ -237,7 +237,8 @@ class ChapelObject(ObjectDescription):
 
     def _is_attr_like(self):
         """Returns True when objtype is attribute or data."""
-        return self.objtype in ('attribute', 'data', 'type', 'enum', 'enumelement')
+        return self.objtype in ('attribute', 'data',
+                                'type', 'enum', 'enumelement')
 
     def _is_proc_like(self):
         """Returns True when objtype is *function or *method."""

--- a/test/test_chapeldomain.py
+++ b/test/test_chapeldomain.py
@@ -9,7 +9,7 @@ import mock
 import unittest
 
 from sphinxcontrib.chapeldomain import (
-    ChapelDomain, ChapelModuleIndex, ChapelModuleLevel, ChapelObject,
+    ChapelDomain, ChapelModuleIndex, ChapelClassObject, ChapelModuleLevel, ChapelObject,
     ChapelTypedField, ChapelClassMember,
     chpl_sig_pattern, chpl_attr_sig_pattern,
 )
@@ -183,6 +183,17 @@ class ChapelObjectTestCase(unittest.TestCase):
         o.objtype = objtype
         return o
 
+class ChapelModuleLevelTests(ChapelObjectTestCase):
+    """ChapelClassObject tests."""
+
+    object_cls = ChapelClassObject
+
+    def test_get_index_test__enum__mod(self):
+        """Verify get_index_test() for enum with module."""
+        mod = self.new_obj('enum')
+        expected_text = 'Color (enum in MyMod)'
+        actual_text = mod.get_index_text('MyMod', ('Color',))
+        self.assertEqual(expected_text, actual_text)
 
 class ChapelModuleLevelTests(ChapelObjectTestCase):
     """ChapelModuleLevel tests."""

--- a/test/test_chapeldomain.py
+++ b/test/test_chapeldomain.py
@@ -338,7 +338,7 @@ class ChapelObjectTests(ChapelObjectTestCase):
         """Verify _is_attr_like return True for data and
         attribute directives.
         """
-        for objtype in ('data', 'attribute', 'type', 'enum'):
+        for objtype in ('data', 'attribute', 'type', 'enum','enumconstant'):
             self.assertTrue(self.new_obj(objtype)._is_attr_like())
 
     def test_needs_arglist(self):
@@ -399,6 +399,7 @@ class ChapelObjectTests(ChapelObjectTestCase):
             'module',
             'random',
             'enum',
+            'enumconstant',
             '',
         ]
         for objtype in bad_dirs:
@@ -416,6 +417,7 @@ class ChapelObjectTests(ChapelObjectTestCase):
             ('config const n', 'config const '),
             ('blah blah blah blah blah', 'blah blah blah blah '),
             ('enum Color', 'enum '),
+            ('enum constant USA', 'enum constant '),
         ]
         for objtype in ('attribute', 'data'):
             obj = self.new_obj(objtype)
@@ -933,6 +935,10 @@ class AttrSigPatternTests(PatternTestCase):
             ('enum Color { Red, Yellow, Blue }', 'enum ', None, 'Color', ' { Red, Yellow, Blue }'),
             ('enum Month { January=1, February }', 'enum ', None, 'Month', ' { January=1, February }'),
             ('enum One { Neo }', 'enum ', None, 'One', ' { Neo }'),
+            ('enum constant Pink', 'enum constant ', None, 'Pink', None),
+            ('enum constant December', 'enum constant ', None, 'December', None),
+            ('enum constant Hibiscus', 'enum constant ', None, 'Hibiscus', None),
+            ('enum constant Aquarius', 'enum constant ', None, 'Aquarius', None)
         ]
         for sig, prefix, class_name, attr, type_name in test_cases:
             self.check_sig(sig, prefix, class_name, attr, type_name)


### PR DESCRIPTION
Implement `enumconstant`and its documentation. These changes, along with [PR #22750](https://github.com/chapel-lang/chapel/pull/22750), allow `chpldoc` to generate documentation for each enum constant rather than only for the enum. Solution to https://github.com/chapel-lang/chapel/issues/5022.

Previously, documentation for enum constants have been either nonexistent, or written in different ways (such as a table) in order to be shown. Since this form of documentation is already available for other attribute-like types (i.e. records), it is intuitive for enum constant documentation to exist as well.

This PR changes `enum` to a Class Object and `enumconstant` to a Class Member (suggested by Thomas Van Doren in 2015). It includes test cases for `enumconstant` and presents the changes made in [PR #22750](https://github.com/chapel-lang/chapel/pull/22750).

An example of affected code:
<img width="400" alt="Screenshot 2023-07-25 at 5 08 17 PM" src="https://github.com/chapel-lang/sphinxcontrib-chapeldomain/assets/68715194/d9018c0b-86ae-4155-87a9-293b1fb1dac1">
<img width="400" alt="Screenshot 2023-07-25 at 5 11 14 PM" src="https://github.com/chapel-lang/sphinxcontrib-chapeldomain/assets/68715194/665cffba-edb7-4b4b-8734-f092cf2eff64">
<img width="400" alt="Screenshot 2023-07-25 at 5 07 05 PM" src="https://github.com/chapel-lang/sphinxcontrib-chapeldomain/assets/68715194/cdf95055-5003-431b-90e1-cfe84499492a">
