### PR TITLE
Fix signature regex to match more possible operator names

### DIFF
--- a/sphinxcontrib/chapeldomain/__init__.py
+++ b/sphinxcontrib/chapeldomain/__init__.py
@@ -46,7 +46,11 @@ chpl_sig_pattern = re.compile(
                                                    #  (type, param, ref)
           )?
           ([\w$.]*\.)?                             # class name(s)
-          ([\w\+\-/\*$\<\=\>\!]+)  \s*             # function or method name
+          \s*?
+          (
+           (?:[\w$][\w$=]*)|                       # function or method name
+           (?:[+*/!~%<>=&^|\-:]+)                  #  or operator name
+          )  \s*
           (?:\((.*?)\))?                           # opt: arguments
           (\s+(?:const\s)? (?:\w+?)|               #  or return intent
            \s* : \s* (?:[^:]+?)|                   #  or return type

--- a/test/test_chapeldomain.py
+++ b/test/test_chapeldomain.py
@@ -840,8 +840,11 @@ class SigPatternTests(PatternTestCase):
             ('operator *(s: string, n: integral) : string', 'operator ', None, '*', 's: string, n: integral', ' : string', None),
             ('inline operator string.==(param s0: string, param s1: string) param', 'inline operator ', 'string.', '==', 'param s0: string, param s1: string', ' param', None),
             ('operator bytes.=(ref lhs: bytes, rhs: bytes) : void ', 'operator ', 'bytes.', '=', 'ref lhs: bytes, rhs: bytes', ' : void ', None),
-            # can't handle this pattern, ":" is set as punctuation, and casts don't seem to be doc'd anyway
-            # ('operator :(x: bytes)', 'operator ', None, ':', 'x: bytes', None),
+            ('operator :(x: bytes)', 'operator ', None, ':', 'x: bytes', None, None),
+            ('proc x: int', 'proc ', None, 'x', None, ': int', None),
+            ('proc x ref: int', 'proc ', None, 'x', None, ' ref: int', None),
+            ('proc foo.bar: int', 'proc ', 'foo.', 'bar', None, ': int', None),
+            ('proc foo.bar ref: int', 'proc ', 'foo.', 'bar', None, ' ref: int', None),
          ]
         for sig, prefix, class_name, name, arglist, retann, where_clause in test_cases:
             self.check_sig(sig, prefix, class_name, name, arglist, retann, where_clause)


### PR DESCRIPTION
Fixes a bug where operator names would not be displayed correctly and where not linkable (chapel-lang/chapel#17057). This was due to the chpl signature regex not matching all possible operators like `~` or `|`.