### PR TITLE
Update the domain's dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 # Note: DON'T UPDATE THIS WITHOUT ALSO UPDATING SETUP.PY
 docutils==0.16
-Sphinx==4.5.0
+Sphinx==5.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 # Note: DON'T UPDATE THIS WITHOUT ALSO UPDATING SETUP.PY
-docutils==0.16
+docutils==0.19
 Sphinx==5.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 # Note: DON'T UPDATE THIS WITHOUT ALSO UPDATING SETUP.PY
-docutils==0.19
+docutils==0.18
 Sphinx==5.3.0

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     packages=find_packages(exclude=('test',)),
     include_package_data=True,
     install_requires=[
-        'docutils==0.16',
+        'docutils==0.19',
         'Sphinx==5.3.0',
     ],
     namespace_packages=['sphinxcontrib']

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     packages=find_packages(exclude=('test',)),
     include_package_data=True,
     install_requires=[
-        'docutils==0.19',
+        'docutils==0.18',
         'Sphinx==5.3.0',
     ],
     namespace_packages=['sphinxcontrib']

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'docutils==0.16',
-        'Sphinx==4.5.0',
+        'Sphinx==5.3.0',
     ],
     namespace_packages=['sphinxcontrib']
 )

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-flake8==5.0.4
+flake8==7.0.0
 mock
 pytest==7.1.2
 pytest-cov

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,5 @@
 flake8==7.0.0
 mock
-pytest==7.1.2
+pytest==7.4.4
 pytest-cov
 tox


### PR DESCRIPTION
This is needed because Sphinx is dropping support for versions older than 5 (by updating their required dependencies)

Updates:
- Sphinx to 5.3.0
- docutils to 0.18
- flake8 to 7.0.0
- pytest to 7.4.4

Note:
- Latest version of Sphinx is 7.2.6, but it requires later versions of Python than we tend to test, and I would want to talk to the team before making that decision.
- Latest version of docutils is 0.20.1, but Sphinx 5.3.0 doesn't work with versions after 0.20 and 0.19 generated a lot of failures about a missing "reporter".  Worth investigating, but not right now