### PR TITLE
Fix an issue with the script to generate a release

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 # Note: DON'T UPDATE THIS WITHOUT ALSO UPDATING SETUP.PY
 docutils==0.18
 Sphinx==5.3.0
+setuptools==54.0.0

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
     install_requires=[
         'docutils==0.18',
         'Sphinx==5.3.0',
+        'setuptools==54.0.0',
     ],
     namespace_packages=['sphinxcontrib']
 )


### PR DESCRIPTION
Add setuptools as a requirement to build the domain, since it seems as though the version of Python we are now using to create our release doesn't include it by default.

----
Signed-off-by: Lydia Duncan <lydia-duncan@users.noreply.github.com>