### PR TITLE
Add fix for return intent formatting in chromium browsers

### DIFF
--- a/sphinxcontrib/chapeldomain/__init__.py
+++ b/sphinxcontrib/chapeldomain/__init__.py
@@ -205,6 +205,27 @@ class ChapelObject(ObjectDescription):
         else:
             signode += paramlist
 
+    @staticmethod
+    def _handle_signature_suffix(signode, retann, anno, where_clause):
+        """handle the signature suffix items like return intent, return type, where clause, annotation, etc."""
+        if retann:
+            if ':' in retann:
+                retintent, _, rettype = retann.partition(':')
+                rettype.strip()
+            else:
+                retintent, rettype = retann, None
+            retintent = retintent.strip()
+            if retintent:
+                signode += addnodes.desc_sig_space(' ', ' ')
+                signode += addnodes.desc_annotation(' ' + retintent, ' ' + retintent)
+            if rettype:
+                signode += addnodes.desc_annotation(' : ' + rettype, ' : ' + rettype)
+        if anno:
+            signode += addnodes.desc_annotation(' ' + anno, ' ' + anno)
+        if where_clause:
+            signode += addnodes.desc_annotation(' ' + where_clause,
+                                                ' ' + where_clause)
+
     def _get_attr_like_prefix(self, sig):
         """Return prefix text for attribute or data directive."""
         sig_match = chpl_attr_sig_pattern.match(sig)
@@ -355,23 +376,12 @@ class ChapelObject(ObjectDescription):
             if self.needs_arglist() and arglist is not None:
                 # for callables, add an empty parameter list
                 signode += addnodes.desc_parameterlist()
-            if retann:
-                signode += addnodes.desc_type(retann, retann)
-            if anno:
-                signode += addnodes.desc_annotation(' ' + anno, ' ' + anno)
-            if where_clause:
-                signode += addnodes.desc_annotation(' ' + where_clause,
-                                                    ' ' + where_clause)
+            self._handle_signature_suffix(signode, retann, anno, where_clause)
             return fullname, name_prefix
 
         self._pseudo_parse_arglist(signode, arglist)
-        if retann:
-            signode += addnodes.desc_type(retann, retann)
-        if anno:
-            signode += addnodes.desc_annotation(' ' + anno, ' ' + anno)
-        if where_clause:
-            signode += addnodes.desc_annotation(' ' + where_clause,
-                                                ' ' + where_clause)
+        self._handle_signature_suffix(signode, retann, anno, where_clause)
+
         return fullname, name_prefix
 
     def get_index_text(self, modname, name):

--- a/sphinxcontrib/chapeldomain/__init__.py
+++ b/sphinxcontrib/chapeldomain/__init__.py
@@ -217,9 +217,11 @@ class ChapelObject(ObjectDescription):
             retintent = retintent.strip()
             if retintent:
                 signode += addnodes.desc_sig_space(' ', ' ')
-                signode += addnodes.desc_annotation(' ' + retintent, ' ' + retintent)
+                signode += addnodes.desc_annotation(' ' + retintent,
+                                                    ' ' + retintent)
             if rettype:
-                signode += addnodes.desc_annotation(' : ' + rettype, ' : ' + rettype)
+                signode += addnodes.desc_annotation(' : ' + rettype,
+                                                    ' : ' + rettype)
         if anno:
             signode += addnodes.desc_annotation(' ' + anno, ' ' + anno)
         if where_clause:

--- a/sphinxcontrib/chapeldomain/__init__.py
+++ b/sphinxcontrib/chapeldomain/__init__.py
@@ -211,7 +211,7 @@ class ChapelObject(ObjectDescription):
         if retann:
             if ':' in retann:
                 retintent, _, rettype = retann.partition(':')
-                rettype.strip()
+                rettype = rettype.strip()
             else:
                 retintent, rettype = retann, None
             retintent = retintent.strip()

--- a/sphinxcontrib/chapeldomain/__init__.py
+++ b/sphinxcontrib/chapeldomain/__init__.py
@@ -207,7 +207,10 @@ class ChapelObject(ObjectDescription):
 
     @staticmethod
     def _handle_signature_suffix(signode, retann, anno, where_clause):
-        """handle the signature suffix items like return intent, return type, where clause, annotation, etc."""
+        """
+        handle the signature suffix items like return intent, return type,
+        where clause, annotation, etc.
+        """
         if retann:
             if ':' in retann:
                 retintent, _, rettype = retann.partition(':')


### PR DESCRIPTION
Fixes how return intents (and by proxy return types) are formatted in chromium based browsers

Before this PR
<img width="276" alt="Screenshot 2024-03-04 at 9 50 12 AM" src="https://github.com/chapel-lang/sphinxcontrib-chapeldomain/assets/15747900/238f9d31-a5f5-4581-b6f1-8dd87420d32d">
<img width="237" alt="Screenshot 2024-03-04 at 1 31 01 PM" src="https://github.com/chapel-lang/sphinxcontrib-chapeldomain/assets/15747900/59bbd21c-6d89-4fe3-ab2c-ffd04ed5e11b">


After this PR
<img width="298" alt="Screenshot 2024-03-04 at 9 50 22 AM" src="https://github.com/chapel-lang/sphinxcontrib-chapeldomain/assets/15747900/6e3a8f74-b5f8-4c33-8774-b0e9cac65ab0">
<img width="247" alt="Screenshot 2024-03-04 at 1 29 52 PM" src="https://github.com/chapel-lang/sphinxcontrib-chapeldomain/assets/15747900/fe8253b3-46ec-4cf3-bfa9-efdf7da229a1">

[Reviewed by @lydia-duncan]
