### PR TITLE
Fix links for nested types

### DIFF
--- a/doc-test/index.rst
+++ b/doc-test/index.rst
@@ -21,6 +21,7 @@ Module 'Foo'
    Containers
    foo
    cpp_test
+   nested
 
 **Does it work???**
 

--- a/doc-test/nested.rst
+++ b/doc-test/nested.rst
@@ -1,5 +1,8 @@
 .. default-domain:: chpl
 
+Module: MyMod
+==============
+
 .. module:: MyMod
 
 .. record:: TopLevel

--- a/doc-test/nested.rst
+++ b/doc-test/nested.rst
@@ -1,0 +1,19 @@
+.. default-domain:: chpl
+
+.. module:: MyMod
+
+.. record:: TopLevel
+
+   .. method:: proc foo
+
+   .. record:: Inner
+
+      .. method:: proc bar
+
+   .. method:: proc baz
+
+.. record:: TopLevel2
+
+   .. record:: Inner
+
+      .. method:: proc bar

--- a/sphinxcontrib/chapeldomain/__init__.py
+++ b/sphinxcontrib/chapeldomain/__init__.py
@@ -422,19 +422,6 @@ class ChapelObject(ObjectDescription):
             self.indexnode['entries'].append(('single', indextext,
                                               fullname, '', None))
 
-    def before_content(self):
-        """Called before parsing content. Set flag to help with class scoping.
-        """
-        self.clsname_set = False
-
-    def after_content(self):
-        """Called after parsing content. If any classes were added to the env
-        temp_data, make sure they are removed.
-        """
-        if self.clsname_set:
-            self.env.temp_data.pop('chpl:class', None)
-
-
 class ChapelModule(Directive):
     """Directive to make description of a new module."""
 
@@ -596,7 +583,19 @@ class ChapelClassObject(ChapelObject):
         ChapelObject.before_content(self)
         if self.names:
             self.env.temp_data['chpl:class'] = self.names[0][0]
-            self.clsname_set = True
+            if not hasattr(self, 'clsname_set'):
+                self.clsname_set = 0
+            self.clsname_set += 1
+
+    def after_content(self):
+        """Called after parsing content. Pop the class name from the class name"""
+        if self.clsname_set > 0:
+            val = self.env.temp_data.pop('chpl:class', None)
+            if val:
+                elms = val.split('.')[:-1]
+                self.env.temp_data['chpl:class'] ='.'.join(elms)
+            self.clsname_set -= 1
+
 
 
 class ChapelModuleLevel(ChapelObject):

--- a/sphinxcontrib/chapeldomain/__init__.py
+++ b/sphinxcontrib/chapeldomain/__init__.py
@@ -589,8 +589,8 @@ class ChapelClassObject(ChapelObject):
             self.clsname_set += 1
 
     def after_content(self):
-        """Called after parsing content. Pop the class name from the class
-        name
+        """Called after parsing content. Pop the class name from the longer
+        class name
         """
         if self.clsname_set > 0:
             val = self.env.temp_data.pop('chpl:class', None)

--- a/sphinxcontrib/chapeldomain/__init__.py
+++ b/sphinxcontrib/chapeldomain/__init__.py
@@ -422,6 +422,7 @@ class ChapelObject(ObjectDescription):
             self.indexnode['entries'].append(('single', indextext,
                                               fullname, '', None))
 
+
 class ChapelModule(Directive):
     """Directive to make description of a new module."""
 
@@ -595,9 +596,8 @@ class ChapelClassObject(ChapelObject):
             val = self.env.temp_data.pop('chpl:class', None)
             if val:
                 elms = val.split('.')[:-1]
-                self.env.temp_data['chpl:class'] ='.'.join(elms)
+                self.env.temp_data['chpl:class'] = '.'.join(elms)
             self.clsname_set -= 1
-
 
 
 class ChapelModuleLevel(ChapelObject):

--- a/sphinxcontrib/chapeldomain/__init__.py
+++ b/sphinxcontrib/chapeldomain/__init__.py
@@ -588,7 +588,9 @@ class ChapelClassObject(ChapelObject):
             self.clsname_set += 1
 
     def after_content(self):
-        """Called after parsing content. Pop the class name from the class name"""
+        """Called after parsing content. Pop the class name from the class
+        name
+        """
         if self.clsname_set > 0:
             val = self.env.temp_data.pop('chpl:class', None)
             if val:


### PR DESCRIPTION
This PR adjusts the handling of class names to correctly create links for nested types.

See `doc-test/nested.rst` for an example. Previously `MyMod.TopLevel.baz` would incorrectly be linked as `MyMod.baz`

[Reviewed by @lydia-duncan]