### PR TITLE
Update dependencies: docutils 0.20.1, Sphinx 7.2.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 # Note: DON'T UPDATE THIS WITHOUT ALSO UPDATING SETUP.PY
-docutils==0.18
-Sphinx==5.3.0
+docutils==0.20.1
+Sphinx==7.2.6

--- a/setup.py
+++ b/setup.py
@@ -42,8 +42,8 @@ setup(
     packages=find_packages(exclude=('test',)),
     include_package_data=True,
     install_requires=[
-        'docutils==0.18',
-        'Sphinx==5.3.0',
+        'docutils==0.20.1',
+        'Sphinx==7.2.6',
     ],
     namespace_packages=['sphinxcontrib']
 )

--- a/test/test_chapeldomain.py
+++ b/test/test_chapeldomain.py
@@ -169,14 +169,14 @@ class ChapelObjectTestCase(unittest.TestCase):
         """Return new mocked out ChapelObject"""
         default_args = {
             'name': 'my-chpl',
-            'arguments': mock.Mock('arguments'),
-            'options': mock.Mock('options'),
-            'content': mock.Mock('content'),
-            'lineno': mock.Mock('lineno'),
-            'content_offset': mock.Mock('content_offset'),
-            'block_text': mock.Mock('block_text'),
-            'state': mock.Mock('state'),
-            'state_machine': mock.Mock('state_machine'),
+            'arguments': mock.Mock(name='arguments'),
+            'options': mock.Mock(name='options'),
+            'content': mock.Mock(name='content'),
+            'lineno': mock.Mock(name='lineno'),
+            'content_offset': mock.Mock(name='content_offset'),
+            'block_text': mock.Mock(name='block_text'),
+            'state': mock.Mock(name='state'),
+            'state_machine': mock.Mock(name='state_machine', spec=["reporter",]),
         }
         default_args.update(kwargs)
         o = self.object_cls(**default_args)


### PR DESCRIPTION
This is to go along with https://github.com/chapel-lang/chapel/pull/24612 . The changes to test/test_chapeldomain.py avoid a problem when using docutils 0.19 or newer that came up with the way the test was using mocked objects.

Reviewed by @lydia-duncan - thanks!