### PR TITLE
Bump version number for next release

### DIFF
--- a/sphinxcontrib/chapeldomain/__init__.py
+++ b/sphinxcontrib/chapeldomain/__init__.py
@@ -35,7 +35,7 @@ from sphinx.util.nodes import make_refnode
 
 from sphinxcontrib.chapeldomain.chapel import ChapelLexer
 
-VERSION = '0.0.32'
+VERSION = '0.0.33'
 
 
 # regex for parsing proc, iter, class, record, etc.


### PR DESCRIPTION
This PR just bumps the version number to 0.0.33 in preparation for the next release.