### PR TITLE
Bump version number to 0.0.34

### DIFF
--- a/sphinxcontrib/chapeldomain/__init__.py
+++ b/sphinxcontrib/chapeldomain/__init__.py
@@ -35,7 +35,7 @@ from sphinx.util.nodes import make_refnode
 
 from sphinxcontrib.chapeldomain.chapel import ChapelLexer
 
-VERSION = '0.0.33'
+VERSION = '0.0.34'
 
 
 # regex for parsing proc, iter, class, record, etc.


### PR DESCRIPTION
Verifying that our action to push to PyPI again worked pushed a version with 0.0.33 so we can't use that version number any more.  Bump to the next one

----
Signed-off-by: Lydia Duncan <lydia-duncan@users.noreply.github.com>