### PR TITLE
Add support for interfaces

### DIFF
--- a/doc-test/classes.rst
+++ b/doc-test/classes.rst
@@ -13,7 +13,7 @@ Chapel classes
 
 .. class:: ChplVector
 
-    See also :chpl:record:`ChplBigNum`. The :chpl:iter:`these` iterator can be
+    See also :chpl:record:`ChplBigNum` and :chpl:interface:`ChplInterface`. The :chpl:iter:`these` iterator can be
     used to iterate over the elements of the vector.
 
     .. attribute:: type eltType
@@ -101,6 +101,14 @@ Chapel classes
         :rtype: bool
         :returns: True if read was successful.
 
+
+.. interface:: ChplInterface
+
+    Some text goes here
+
+    .. method:: proc Self.foo()
+
+        Some method that does something.
 
 Python classes
 --------------

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -157,6 +157,11 @@ For example, this would document a module with a ``proc`` and an ``iter``::
 
     Records work the same as :rst:dir:`chpl:class`.
 
+
+.. directive:: .. chpl:interface:: signature
+
+    Interfaces work the same as :rst:dir:`chpl:class`.
+
 .. directive:: .. chpl:attribute:: signature
 
     Describes an object data attribute. This can be a ``param``, ``const``,

--- a/sphinxcontrib/chapeldomain/__init__.py
+++ b/sphinxcontrib/chapeldomain/__init__.py
@@ -41,7 +41,9 @@ VERSION = '0.0.34'
 # regex for parsing proc, iter, class, record, etc.
 chpl_sig_pattern = re.compile(
     r"""^ ((?:\w+\s+)*                             # opt: prefixes
-           (?:proc|iter|class|record|interface|operator)\s+  # must end with keyword
+           (?:
+            proc|iter|class|record|interface|operator # must end with keyword
+           )\s+
            (?:type\s+|param\s+|ref\s+)?            # opt: 'this' intent
                                                    #  (type, param, ref)
           )?

--- a/sphinxcontrib/chapeldomain/__init__.py
+++ b/sphinxcontrib/chapeldomain/__init__.py
@@ -41,7 +41,7 @@ VERSION = '0.0.34'
 # regex for parsing proc, iter, class, record, etc.
 chpl_sig_pattern = re.compile(
     r"""^ ((?:\w+\s+)*                             # opt: prefixes
-           (?:proc|iter|class|record|operator)\s+  # must end with keyword
+           (?:proc|iter|class|record|interface|operator)\s+  # must end with keyword
            (?:type\s+|param\s+|ref\s+)?            # opt: 'this' intent
                                                    #  (type, param, ref)
           )?
@@ -570,7 +570,7 @@ class ChapelClassObject(ChapelObject):
 
     def get_index_text(self, modname, name_cls):
         """Return index entry text based on object type."""
-        if self.objtype in ('class', 'record', 'enum'):
+        if self.objtype in ('class', 'record', 'interface', 'enum'):
             if not modname:
                 return _('%s (built-in %s)') % (name_cls[0], self.objtype)
             return _('%s (%s in %s)') % (name_cls[0], self.objtype, modname)
@@ -806,6 +806,7 @@ class ChapelDomain(Domain):
         'enumconstant': ObjType(_('enumconstant'), 'enumconstant'),
         'class': ObjType(_('class'), 'class'),
         'record': ObjType(_('record'), 'record'),
+        'interface': ObjType(_('interface'), 'interface'),
         'method': ObjType(_('method'), 'meth', 'proc'),
         'itermethod': ObjType(_('itermethod'), 'meth', 'iter'),
         'attribute': ObjType(_('attribute'), 'attr'),
@@ -823,6 +824,7 @@ class ChapelDomain(Domain):
 
         'class': ChapelClassObject,
         'record': ChapelClassObject,
+        'interface': ChapelClassObject,
         'enum': ChapelClassObject,
         'enumconstant': ChapelClassMember,
         'method': ChapelClassMember,
@@ -844,6 +846,7 @@ class ChapelDomain(Domain):
         'iter': ChapelXRefRole(),
         'class': ChapelXRefRole(),
         'record': ChapelXRefRole(),
+        'interface': ChapelXRefRole(),
         'enum': ChapelXRefRole(),
         'enumconstant': ChapelXRefRole(),
         'meth': ChapelXRefRole(),

--- a/test/test_chapeldomain.py
+++ b/test/test_chapeldomain.py
@@ -377,6 +377,7 @@ class ChapelObjectTests(ChapelObjectTestCase):
             'itermethod',
             'class',
             'record',
+            'interface',
             'module',
             'random',
             'opmethod',
@@ -407,6 +408,7 @@ class ChapelObjectTests(ChapelObjectTestCase):
             'type',
             'class',
             'record',
+            'interface',
             'module',
             'random',
             'enum',
@@ -799,7 +801,7 @@ class SigPatternTests(PatternTestCase):
     def test_with_all(self):
         """Verify fully specified signatures parse correctly."""
         test_cases = [
-            ('proc foo where a > b', 'proc ', None, 'foo', None, None, ' where a > b'), 
+            ('proc foo where a > b', 'proc ', None, 'foo', None, None, ' where a > b'),
             ('proc foo() where a > b', 'proc ', None, 'foo', '', None, ' where a > b'), 
             ('proc foo:int where a > b', 'proc ', None, 'foo', None, ':int', ' where a > b'), 
             ('proc foo():int where a > b', 'proc ', None, 'foo', '', ':int', ' where a > b'), 
@@ -829,6 +831,7 @@ class SigPatternTests(PatternTestCase):
             ('record R', 'record ', None, 'R', None, None, None),
             ('record MyRec:SuRec', 'record ', None, 'MyRec', None, ':SuRec', None),
             ('record N.R : X, Y, Z', 'record ', 'N.', 'R', None, ': X, Y, Z', None),
+            ('interface I', 'interface ', None, 'I', None, None, None),
             ('proc rcRemote(replicatedVar: [?D] ?MYTYPE, remoteLoc: locale) ref: MYTYPE',
              'proc ', None, 'rcRemote', 'replicatedVar: [?D] ?MYTYPE, remoteLoc: locale', ' ref: MYTYPE', None),
             ('proc rcLocal(replicatedVar: [?D] ?MYTYPE) ref: MYTYPE',


### PR DESCRIPTION
Adds support for `interface`, which will be outputed by chpldoc after https://github.com/chapel-lang/chapel/pull/25825

[Reviewed by @lydia-duncan]