### PR TITLE
Pin sphinx_rtd_theme to the previous version for now

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,1 +1,1 @@
-sphinx_rtd_theme
+sphinx_rtd_theme==2.0.0


### PR DESCRIPTION
It looks like a new version was pushed last night and that triggered a deprecation warning with Sphinx in our nightly testing.  I have an action item to look into updating the various package versions we rely on in other places, but for now pin to the older version

----
Signed-off-by: Lydia Duncan <lydia-duncan@users.noreply.github.com>