### PR TITLE
Update dependencies to more recent releases

### DIFF
--- a/doc-test/conf.py
+++ b/doc-test/conf.py
@@ -107,7 +107,6 @@ pygments_style = 'sphinx'
 if not on_rtd:  # only import and set the theme if we're building docs locally
     import sphinx_rtd_theme
     html_theme = 'sphinx_rtd_theme'
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,1 +1,1 @@
-sphinx_rtd_theme==2.0.0
+sphinx_rtd_theme==3.0.0

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,3 +1,3 @@
 sphinx_rtd_theme==3.0.2
-snowballstemmer==2.2.0
+snowballstemmer==3.0.1
 

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,3 +1,3 @@
-sphinx_rtd_theme==3.0.0
+sphinx_rtd_theme==3.0.2
 snowballstemmer==2.2.0
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -109,7 +109,6 @@ pygments_style = 'sphinx'
 if not on_rtd:
     import sphinx_rtd_theme
     html_theme = 'sphinx_rtd_theme'
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 # Note: DON'T UPDATE THIS WITHOUT ALSO UPDATING SETUP.PY
 docutils==0.21.2
-Sphinx==8.0.2
+Sphinx==8.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 # Note: DON'T UPDATE THIS WITHOUT ALSO UPDATING SETUP.PY
-docutils==0.20.1
-Sphinx==7.2.6
+docutils==0.21.2
+Sphinx==8.0.2

--- a/setup.py
+++ b/setup.py
@@ -42,8 +42,8 @@ setup(
     packages=find_packages(exclude=('test',)),
     include_package_data=True,
     install_requires=[
-        'docutils==0.20.1',
-        'Sphinx==7.2.6',
+        'docutils==0.21.2',
+        'Sphinx==8.0.2',
     ],
     namespace_packages=['sphinxcontrib']
 )

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'docutils==0.21.2',
-        'Sphinx==8.0.2',
+        'Sphinx==8.1.3',
     ],
     namespace_packages=['sphinxcontrib']
 )

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,5 @@
-flake8==7.0.0
+flake8==7.1.1
 mock
-pytest==7.4.4
+pytest==8.3.3
 pytest-cov
 tox

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-flake8==7.1.1
+flake8==7.3.0
 mock
 pytest==8.3.3
 pytest-cov

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,5 @@
 flake8==7.3.0
 mock
-pytest==8.3.3
+pytest==8.4.1
 pytest-cov
 tox


### PR DESCRIPTION
[reviewed by @jabraham17]

Updates:
- Sphinx from 7.2.6 to 8.1.3
- docutils from 0.20.1 to 0.21.2
- sphinx_rtd_theme from 2.0.0 to 3.0.2
- flake8 from 7.0.0 to 7.3.0
- pytest from 7.4.4 to 8.4.1
- snowballstemmer from 2.2.0 to 3.0.1

All of these are the most up-to-date version, except for Sphinx which would drop support for Python 3.10 as well as 3.9.