### PR TITLE
Pin version of snowballstemmer

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,1 +1,2 @@
 sphinx_rtd_theme==2.0.0
+snowballstemmer==2.2.0


### PR DESCRIPTION
This was relied on by one of our other dependencies (likely through a more extensive dependency chain).  It updated its most recent version to 3.0.0 today and that broke our documentation tests, so pin to an older version for now while I figure out:
1. what package is using it
2. whether it's necessary to be using that dependency
