### PR TITLE
Fix rendering of variables

### DIFF
--- a/doc-test/index.rst
+++ b/doc-test/index.rst
@@ -22,6 +22,7 @@ Module 'Foo'
    foo
    cpp_test
    nested
+   variables
 
 **Does it work???**
 

--- a/doc-test/variables.rst
+++ b/doc-test/variables.rst
@@ -1,0 +1,20 @@
+Variables
+=========
+
+
+
+Chapel variables
+----------------
+
+.. default-domain:: chpl
+
+.. module:: Variables
+    :synopsis: Variables, constants, and configuration parameters.
+
+.. data:: param e = 2.7182818284590452354
+
+    This is a constant.
+
+.. data:: param pi: real = 3.1415926535897932385
+
+    This is another constant.

--- a/sphinxcontrib/chapeldomain/__init__.py
+++ b/sphinxcontrib/chapeldomain/__init__.py
@@ -129,6 +129,7 @@ chpl_attr_sig_pattern = re.compile(
           (\s*[={]\s*.+)?         # optional: value
           $""", re.VERBOSE)
 
+
 def match_chpl_attr_sig_pattern(sig: str):
     """
     Match a Chapel signature against the regex pattern defined in
@@ -154,6 +155,7 @@ def match_chpl_attr_sig_pattern(sig: str):
         default_value = default_value.strip()
 
     return (func_prefix, name_prefix, name, return_type, default_value)
+
 
 # This would be the ideal way to create a chapelerific desc_returns similar to
 # addnodes.desc_returns. However, due to some update issue, the


### PR DESCRIPTION
Fixes the rendering of variables, which after https://github.com/chapel-lang/sphinxcontrib-chapeldomain/pull/103 would always have extra colons being inserted, due to how variables are parsed. This PR makes similar transformations as #103 did to separate types and default values to solve this problem