### PR TITLE
Avoid a deprecation warning when pushing a release to test.pypi.org

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -70,4 +70,4 @@ jobs:
       with:
         user: __token__
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-        repository_url: https://test.pypi.org/legacy/
+        repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
Discovered when testing that pushing to pypi will work with the new license format

----