### PR TITLE
Replace PyPI mock with unittest.mock

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,4 @@
 flake8==7.3.0
-mock
 pytest==8.4.1
 pytest-cov
 tox

--- a/test/test_chapeldomain.py
+++ b/test/test_chapeldomain.py
@@ -5,8 +5,8 @@
 from __future__ import print_function, unicode_literals
 
 import docutils.nodes as nodes
-import mock
 import unittest
+from unittest import mock
 
 from sphinxcontrib.chapeldomain import (
     ChapelDomain, ChapelModuleIndex, ChapelClassObject, ChapelModuleLevel, ChapelObject,


### PR DESCRIPTION
The standard library has contained unittest.mock since Python 3.3.

See also https://fedoraproject.org/wiki/Changes/DeprecatePythonMock for details and context.