### PR TITLE
Account for the chapel.py license in the SPDX expression and license files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     url='https://github.com/chapel-lang/sphinxcontrib-chapeldomain',
     download_url='https://pypi.python.org/pypi/sphinxcontrib-chapeldomain',
     license='Apache-2.0 AND BSD-2-Clause',
-    license_files=['LICENSE'],
+    license_files=['LICENSE', 'sphinxcontrib/chapeldomain/LICENSE'],
     author='Chapel Team',
     author_email='chapel+developers@discoursemail.com',
     description='Chapel domain for Sphinx',

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     version=version,
     url='https://github.com/chapel-lang/sphinxcontrib-chapeldomain',
     download_url='https://pypi.python.org/pypi/sphinxcontrib-chapeldomain',
-    license='Apache-2.0',
+    license='Apache-2.0 AND BSD-2-Clause',
     license_files=['LICENSE'],
     author='Chapel Team',
     author_email='chapel+developers@discoursemail.com',


### PR DESCRIPTION
Now that we are using an SPDX expression for the license metadata, we can account for the BSD-2-Clause license
(`sphinxcontrib/chapeldomain/LICENSE`) of `chapel.py`.

See https://peps.python.org/pep-0639/#spdx-license-expression-syntax.

We can also list the applicable license file so that it is included in the `.dist-info` metadata.