### PR TITLE
Packit testing on Fedora

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ var/
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
 *.spec
+# spec files are used for rpm packaging and are included in version control
+!packaging/rpm/fedora/*.spec
 
 # Installer logs
 pip-log.txt

--- a/.packit.yml
+++ b/.packit.yml
@@ -1,0 +1,13 @@
+# https://packit.dev/docs/configuration/
+
+specfile_path: packaging/rpm/fedora/python-sphinxcontrib-chapeldomain.spec
+
+notifications:
+  pull_request:
+    successful_build: true
+
+jobs:
+- job: copr_build
+  trigger: pull_request
+  targets:
+  - fedora-rawhide-x86_64

--- a/packaging/rpm/fedora/python-sphinxcontrib-chapeldomain.spec
+++ b/packaging/rpm/fedora/python-sphinxcontrib-chapeldomain.spec
@@ -1,0 +1,78 @@
+Name:           python-sphinxcontrib-chapeldomain
+Version:        0.0.39
+Release:        %autorelease
+Summary:        Chapel domain for Sphinx
+
+# The entire source is Apache-2.0, except that
+# sphinxcontrib/chapeldomain/README.md is BSD-2-Clause
+# (sphinxcontrib/chapeldomain/LICENSE).
+License:        Apache-2.0 AND BSD-2-Clause
+URL:            https://github.com/chapel-lang/sphinxcontrib-chapeldomain
+# PyPI source does not have documentation
+Source:         %{url}/archive/%{version}/sphinxcontrib-chapeldomain-%{version}.tar.gz
+# Relax pinned dependency requirements
+Patch:          relax-dep-requirements.patch
+
+BuildArch:      noarch
+BuildRequires:  python3-devel
+# Documentation requirements
+BuildRequires:  make
+BuildRequires:  python3dist(sphinx)
+BuildRequires:  python3dist(sphinx-rtd-theme)
+BuildRequires:  python3dist(snowballstemmer)
+BuildRequires:  texinfo
+# Test requirements
+BuildRequires:  python3dist(pytest)
+# chapel.py is vendored from Pygments; see
+# sphinxcontrib/chapeldomain/README.md for justification
+Provides:       bundled(python3dist(pygments))
+
+%global _description %{expand:
+Chapel domain for Sphinx.}
+
+%description %_description
+
+%package -n     python3-sphinxcontrib-chapeldomain
+Summary:        %{summary}
+
+%description -n python3-sphinxcontrib-chapeldomain %_description
+
+
+%prep
+%autosetup -p1 -n sphinxcontrib-chapeldomain-%{version}
+
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+
+%build
+%pyproject_wheel
+pushd docs
+make texinfo
+pushd _build
+pushd texinfo
+makeinfo --docbook ChapelDomain.texi
+popd
+popd
+popd
+
+%install
+%pyproject_install
+%pyproject_save_files -l sphinxcontrib
+mkdir -p %{buildroot}%{_datadir}/help/en/python-sphinxcontrib-chapeldomain
+install -p -m644 docs/_build/texinfo/ChapelDomain.xml \
+   %{buildroot}%{_datadir}/help/en/python-sphinxcontrib-chapeldomain
+
+%check
+%pyproject_check_import
+%pytest
+
+%files -n python3-sphinxcontrib-chapeldomain -f %{pyproject_files}
+%{python3_sitelib}/sphinxcontrib_chapeldomain-%{version}-py%{python3_version}-nspkg.pth
+%doc README.rst
+%doc %dir  %{_datadir}/help/en
+%doc %lang(en) %{_datadir}/help/en/python-sphinxcontrib-chapeldomain
+
+%changelog
+%autochangelog

--- a/packaging/rpm/fedora/relax-dep-requirements.patch
+++ b/packaging/rpm/fedora/relax-dep-requirements.patch
@@ -1,0 +1,23 @@
+diff -ruN sphinxcontrib-chapeldomain-0.0.39/requirements.txt sphinxcontrib-chapeldomain-0.0.39-mod/requirements.txt
+--- sphinxcontrib-chapeldomain-0.0.39/requirements.txt	2025-08-11 21:26:12.000000000 +0300
++++ sphinxcontrib-chapeldomain-0.0.39-mod/requirements.txt	2025-09-21 09:57:18.461907810 +0300
+@@ -1,3 +1,3 @@
+ # Note: DON'T UPDATE THIS WITHOUT ALSO UPDATING SETUP.PY
+-docutils==0.21.2
+-Sphinx==8.1.3
++docutils
++Sphinx
+diff -ruN sphinxcontrib-chapeldomain-0.0.39/setup.py sphinxcontrib-chapeldomain-0.0.39-mod/setup.py
+--- sphinxcontrib-chapeldomain-0.0.39/setup.py	2025-08-11 21:26:12.000000000 +0300
++++ sphinxcontrib-chapeldomain-0.0.39-mod/setup.py	2025-09-21 09:57:58.366269630 +0300
+@@ -42,8 +42,8 @@
+     packages=find_packages(exclude=('test',)),
+     include_package_data=True,
+     install_requires=[
+-        'docutils==0.21.2',
+-        'Sphinx==8.1.3',
++        'docutils',
++        'Sphinx',
+     ],
+     namespace_packages=['sphinxcontrib']
+ )


### PR DESCRIPTION
Additional tests that will make distributing Fedora RPMs easier.

To get it to work, someone with commit access will need to agree to make a Fedora account at:
https://accounts.fedoraproject.org/

and agree to Fedora Code of Conduct, then follow the steps at:

http://packit.dev/docs/guide#1-set-up-packit-integration

Closes #113 