### PR TITLE
Fix the printing for warning for duplicate objects

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,10 +37,10 @@ jobs:
         python3 -m tox -e docs,doc-test
 
     - name: Coverage
-      if: matrix.python-version == '3.13'
+      if: matrix.python-version == '3.10'
       run: |
         python3 -m tox -e coverage
 
     - name: Upload codecov
-      if: matrix.python-version == '3.13'
+      if: matrix.python-version == '3.10'
       uses: codecov/codecov-action@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,12 +9,15 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v2
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
       with:
-        python-version: "3.10"
+        python-version: ${{ matrix.python-version }}
 
     - name: Install dependencies
       run: |
@@ -34,8 +37,10 @@ jobs:
         python3 -m tox -e docs,doc-test
 
     - name: Coverage
+      if: matrix.python-version == '3.13'
       run: |
         python3 -m tox -e coverage
 
     - name: Upload codecov
+      if: matrix.python-version == '3.13'
       uses: codecov/codecov-action@v2

--- a/sphinxcontrib/chapeldomain/__init__.py
+++ b/sphinxcontrib/chapeldomain/__init__.py
@@ -543,11 +543,11 @@ class ChapelObject(ObjectDescription):
             objects = self.env.domaindata['chpl']['objects']
             if fullname in objects:
                 self.state_machine.reporter.warning(
-                    'duplicate object description of %s, ' % fullname +
-                    'other instance in ' +
-                    self.env.doc2path(objects[fullname][0]) +
-                    ', use :noindex: for one of them',
-                    line=self.lineno)
+                    f"duplicate object description of {str(fullname)}, "
+                    + f"other instance in {str( self.env.doc2path(objects[fullname][0]))}, "
+                    + "use :noindex: for one of them",
+                    line=self.lineno,
+                )
             objects[fullname] = (self.env.docname, self.objtype)
 
         indextext = self.get_index_text(modname, name_cls)

--- a/sphinxcontrib/chapeldomain/__init__.py
+++ b/sphinxcontrib/chapeldomain/__init__.py
@@ -542,10 +542,10 @@ class ChapelObject(ObjectDescription):
             self.state.document.note_explicit_target(signode)
             objects = self.env.domaindata['chpl']['objects']
             if fullname in objects:
+                docpath = str(self.env.doc2path(objects[fullname][0]))
                 self.state_machine.reporter.warning(
-                    f"duplicate object description of {str(fullname)}, "
-                    + f"other instance in {str( self.env.doc2path(objects[fullname][0]))}, "
-                    + "use :noindex: for one of them",
+                    f"duplicate object description of {fullname}, other "
+                    + f"instance in {docpath}, use :noindex: for one of them",
                     line=self.lineno,
                 )
             objects[fullname] = (self.env.docname, self.objtype)

--- a/test/test_chapeldomain.py
+++ b/test/test_chapeldomain.py
@@ -568,6 +568,215 @@ class ChapelObjectTests(ChapelObjectTestCase):
             self.assertEqual('config const ', obj._get_sig_prefix('config const x'))
 
 
+class AddTargetAndIndexTests(ChapelObjectTestCase):
+    """Tests for ChapelObject.add_target_and_index()."""
+
+    object_cls = ChapelModuleLevel
+
+    def _make_obj_and_signode(self, objtype, modname=None, names=None,
+                              existing_objects=None, existing_ids=None):
+        """Helper to create a ChapelModuleLevel with mocked internals
+        suitable for calling add_target_and_index().
+        """
+        options = {}
+        if modname is not None:
+            options['module'] = modname
+
+        env = mock.Mock(name='env')
+        env.temp_data = {}
+        env.domaindata = {'chpl': {'objects': dict(existing_objects or {})}}
+        env.docname = 'testdoc'
+        env.doc2path = mock.Mock(side_effect=lambda x: '/docs/' + x + '.rst')
+        env.config.add_module_names = True
+
+        document = mock.Mock(name='document')
+        document.ids = dict.fromkeys(existing_ids or [])
+        document.settings.env = env
+
+        state = mock.Mock(name='state')
+        state.document = document
+
+        state_machine = mock.Mock(name='state_machine',
+                                  spec=['reporter'])
+
+        obj = self.new_obj(
+            objtype,
+            options=options,
+            state=state,
+            state_machine=state_machine,
+        )
+        obj.names = list(names or [])
+        obj.indexnode = {'entries': []}
+
+        signode = {'names': [], 'ids': []}
+        return obj, signode
+
+    def test_simple_function_no_module(self):
+        """Verify add_target_and_index for a simple function without module."""
+        obj, signode = self._make_obj_and_signode('function')
+        obj.env.temp_data['chpl:module'] = None
+
+        obj.add_target_and_index(('myProc', ''), 'myProc()', signode)
+
+        self.assertIn('myProc', signode['names'])
+        self.assertIn('myProc', signode['ids'])
+        self.assertTrue(signode['first'])
+        self.assertEqual(
+            ('testdoc', 'function'),
+            obj.env.domaindata['chpl']['objects']['myProc'],
+        )
+        obj.state.document.note_explicit_target.assert_called_once_with(signode)
+        # function with no module → 'myProc() (built-in procedure)'
+        self.assertEqual(1, len(obj.indexnode['entries']))
+        self.assertEqual('myProc', obj.indexnode['entries'][0][2])
+
+    def test_function_with_module_option(self):
+        """Verify fullname includes module from options."""
+        obj, signode = self._make_obj_and_signode('function', modname='MyMod')
+
+        obj.add_target_and_index(('myProc', ''), 'myProc()', signode)
+
+        fullname = 'MyMod.myProc'
+        self.assertIn(fullname, signode['names'])
+        self.assertIn(fullname, signode['ids'])
+        self.assertEqual(
+            ('testdoc', 'function'),
+            obj.env.domaindata['chpl']['objects'][fullname],
+        )
+        # index entry text: 'myProc() (in module MyMod)'
+        entry = obj.indexnode['entries'][0]
+        self.assertEqual(fullname, entry[2])
+        self.assertIn('MyMod', entry[1])
+
+    def test_function_with_module_from_temp_data(self):
+        """Verify module falls back to env.temp_data['chpl:module']."""
+        obj, signode = self._make_obj_and_signode('function')
+        obj.env.temp_data['chpl:module'] = 'TempMod'
+
+        obj.add_target_and_index(('foo', ''), 'foo()', signode)
+
+        fullname = 'TempMod.foo'
+        self.assertIn(fullname, signode['names'])
+        self.assertEqual(
+            ('testdoc', 'function'),
+            obj.env.domaindata['chpl']['objects'][fullname],
+        )
+
+    def test_module_option_overrides_temp_data(self):
+        """Verify options['module'] takes precedence over temp_data."""
+        obj, signode = self._make_obj_and_signode('function', modname='OptMod')
+        obj.env.temp_data['chpl:module'] = 'TempMod'
+
+        obj.add_target_and_index(('bar', ''), 'bar()', signode)
+
+        self.assertIn('OptMod.bar', signode['names'])
+        self.assertNotIn('TempMod.bar', signode['names'])
+
+    def test_first_flag_true_when_names_empty(self):
+        """Verify signode['first'] is True when self.names is empty."""
+        obj, signode = self._make_obj_and_signode('data', names=[])
+        obj.env.temp_data['chpl:module'] = None
+
+        obj.add_target_and_index(('x', ''), 'x', signode)
+
+        self.assertTrue(signode['first'])
+
+    def test_first_flag_false_when_names_nonempty(self):
+        """Verify signode['first'] is False when self.names is not empty."""
+        obj, signode = self._make_obj_and_signode(
+            'data', names=[('prev', '')])
+        obj.env.temp_data['chpl:module'] = None
+
+        obj.add_target_and_index(('x', ''), 'x', signode)
+
+        self.assertFalse(signode['first'])
+
+    def test_skip_if_already_in_document_ids(self):
+        """Verify no target is added when fullname is already in document.ids."""
+        obj, signode = self._make_obj_and_signode(
+            'function', existing_ids=['myProc'])
+        obj.env.temp_data['chpl:module'] = None
+
+        obj.add_target_and_index(('myProc', ''), 'myProc()', signode)
+
+        self.assertEqual([], signode['names'])
+        self.assertEqual([], signode['ids'])
+        obj.state.document.note_explicit_target.assert_not_called()
+
+    def test_duplicate_object_warning(self):
+        """Verify a warning is emitted for duplicate objects."""
+        existing = {'MyMod.dup': ('other_doc', 'function')}
+        obj, signode = self._make_obj_and_signode(
+            'function', modname='MyMod', existing_objects=existing)
+
+        obj.add_target_and_index(('dup', ''), 'dup()', signode)
+
+        obj.state_machine.reporter.warning.assert_called_once()
+        warning_msg = obj.state_machine.reporter.warning.call_args[0][0]
+        self.assertIn('duplicate object description', warning_msg)
+        self.assertIn('MyMod.dup', warning_msg)
+        # Object should still be overwritten with new location
+        self.assertEqual(
+            ('testdoc', 'function'),
+            obj.env.domaindata['chpl']['objects']['MyMod.dup'],
+        )
+
+    def test_no_warning_for_new_object(self):
+        """Verify no warning when object is new."""
+        obj, signode = self._make_obj_and_signode('function')
+        obj.env.temp_data['chpl:module'] = None
+
+        obj.add_target_and_index(('newFunc', ''), 'newFunc()', signode)
+
+        obj.state_machine.reporter.warning.assert_not_called()
+
+    def test_no_index_entry_when_index_text_empty(self):
+        """Verify no index entry is added when get_index_text returns ''."""
+        # 'attribute' on ChapelModuleLevel returns '' from get_index_text
+        obj, signode = self._make_obj_and_signode('attribute')
+        obj.env.temp_data['chpl:module'] = None
+
+        obj.add_target_and_index(('x', ''), 'x', signode)
+
+        self.assertEqual([], obj.indexnode['entries'])
+
+    def test_index_entry_for_data(self):
+        """Verify index entry is created for data objects."""
+        obj, signode = self._make_obj_and_signode('data', modname='M')
+
+        obj.add_target_and_index(('myVar', ''), 'var myVar', signode)
+
+        self.assertEqual(1, len(obj.indexnode['entries']))
+        entry = obj.indexnode['entries'][0]
+        self.assertEqual('single', entry[0])
+        self.assertEqual('M.myVar', entry[2])
+
+    def test_index_entry_for_type(self):
+        """Verify index entry is created for type objects."""
+        obj, signode = self._make_obj_and_signode('type')
+        obj.env.temp_data['chpl:module'] = None
+
+        obj.add_target_and_index(('MyType', ''), 'type MyType', signode)
+
+        self.assertEqual(1, len(obj.indexnode['entries']))
+        entry = obj.indexnode['entries'][0]
+        self.assertIn('MyType', entry[1])
+        self.assertIn('built-in type', entry[1])
+
+    def test_still_adds_index_when_already_in_ids(self):
+        """Verify index entry is still added even if fullname is in
+        document.ids (the target is skipped but the index is not).
+        """
+        obj, signode = self._make_obj_and_signode(
+            'function', existing_ids=['myFunc'])
+        obj.env.temp_data['chpl:module'] = None
+
+        obj.add_target_and_index(('myFunc', ''), 'myFunc()', signode)
+
+        # index entry should still be added
+        self.assertEqual(1, len(obj.indexnode['entries']))
+
+
 class ChapelTypedFieldTests(ChapelObjectTestCase):
     """Verify ChapelTypedField class."""
 
@@ -1013,6 +1222,8 @@ class AttrSigPatternTests(PatternTestCase):
         ]
         for sig, prefix, class_name, attr, type_name, default_value in test_cases:
             self.check_sig(sig, prefix, class_name, attr, type_name, default_value)
+
+
 
 
 if __name__ == '__main__':

--- a/test/test_chapeldomain.py
+++ b/test/test_chapeldomain.py
@@ -8,6 +8,8 @@ import docutils.nodes as nodes
 import unittest
 from unittest import mock
 
+from pathlib import Path
+
 from sphinxcontrib.chapeldomain import (
     ChapelDomain, ChapelModuleIndex, ChapelClassObject, ChapelModuleLevel, ChapelObject,
     ChapelTypedField, ChapelClassMember,
@@ -586,7 +588,7 @@ class AddTargetAndIndexTests(ChapelObjectTestCase):
         env.temp_data = {}
         env.domaindata = {'chpl': {'objects': dict(existing_objects or {})}}
         env.docname = 'testdoc'
-        env.doc2path = mock.Mock(side_effect=lambda x: '/docs/' + x + '.rst')
+        env.doc2path = mock.Mock(side_effect=lambda x: Path('/docs/' + x + '.rst'))
         env.config.add_module_names = True
 
         document = mock.Mock(name='document')


### PR DESCRIPTION
Fixes the printing for a warning, since `doc2path` may return a path object and not a string

I also ended up using copilot to write a bunch of new tests for that code path (which was untested) and expanding the CI to test multiple Python versions