### PR TITLE
Update plain-HTTP and chapel.cray.com links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,8 +3,8 @@ Chapel Domain for Sphinx
 
 Chapel_ domain for Sphinx_.
 
-.. _Chapel: http://chapel-lang.org/
-.. _Sphinx: http://sphinx-doc.org/
+.. _Chapel: https://chapel-lang.org/
+.. _Sphinx: https://sphinx-doc.org/
 
 .. image:: https://github.com/chapel-lang/sphinxcontrib-chapeldomain/actions/workflows/CI.yml/badge.svg
     :target: https://github.com/chapel-lang/sphinxcontrib-chapeldomain/actions/workflows/CI.yml

--- a/doc-test/Makefile
+++ b/doc-test/Makefile
@@ -9,7 +9,7 @@ BUILDDIR      = _build
 
 # User-friendly check for sphinx-build
 ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 1)
-$(error The '$(SPHINXBUILD)' command was not found. Make sure you have Sphinx installed, then set the SPHINXBUILD environment variable to point to the full path of the '$(SPHINXBUILD)' executable. Alternatively you can add the directory with the executable to your PATH. If you don't have Sphinx installed, grab it from http://sphinx-doc.org/)
+$(error The '$(SPHINXBUILD)' command was not found. Make sure you have Sphinx installed, then set the SPHINXBUILD environment variable to point to the full path of the '$(SPHINXBUILD)' executable. Alternatively you can add the directory with the executable to your PATH. If you don't have Sphinx installed, grab it from https://sphinx-doc.org/)
 endif
 
 # Internal variables.

--- a/doc-test/make.bat
+++ b/doc-test/make.bat
@@ -56,7 +56,7 @@ if errorlevel 9009 (
 	echo.may add the Sphinx directory to PATH.
 	echo.
 	echo.If you don't have Sphinx installed, grab it from
-	echo.http://sphinx-doc.org/
+	echo.https://sphinx-doc.org/
 	exit /b 1
 )
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -9,7 +9,7 @@ BUILDDIR      = _build
 
 # User-friendly check for sphinx-build
 ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 1)
-$(error The '$(SPHINXBUILD)' command was not found. Make sure you have Sphinx installed, then set the SPHINXBUILD environment variable to point to the full path of the '$(SPHINXBUILD)' executable. Alternatively you can add the directory with the executable to your PATH. If you don't have Sphinx installed, grab it from http://sphinx-doc.org/)
+$(error The '$(SPHINXBUILD)' command was not found. Make sure you have Sphinx installed, then set the SPHINXBUILD environment variable to point to the full path of the '$(SPHINXBUILD)' executable. Alternatively you can add the directory with the executable to your PATH. If you don't have Sphinx installed, grab it from https://sphinx-doc.org/)
 endif
 
 # Internal variables.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -270,4 +270,4 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'http://docs.python.org/': None}
+intersphinx_mapping = {'https://docs.python.org/': None}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,8 +6,8 @@ Chapel Domain for Sphinx
 Chapel_ domain for Sphinx_! Document Chapel modules and APIs using the Sphinx
 tool suite.
 
-.. _Chapel: http://chapel-lang.org/
-.. _Sphinx: http://sphinx-doc.org/
+.. _Chapel: https://chapel-lang.org/
+.. _Sphinx: https://sphinx-doc.org/
 
 `Package documentation`_ is available on readthedocs.org.
 

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -56,7 +56,7 @@ if errorlevel 9009 (
 	echo.may add the Sphinx directory to PATH.
 	echo.
 	echo.If you don't have Sphinx installed, grab it from
-	echo.http://sphinx-doc.org/
+	echo.https://sphinx-doc.org/
 	exit /b 1
 )
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -11,7 +11,7 @@ The Chapel domain is strongly influenced by the `Python domain`_ that comes
 with Sphinx. In addition, this documentation takes cues from the documentation
 on Sphinx domain support, including Python domains.
 
-.. _Python domain: http://sphinx-doc.org/domains.html#the-python-domain
+.. _Python domain: https://sphinx-doc.org/domains.html#the-python-domain
 
 Module Directives
 -----------------

--- a/sphinxcontrib/chapeldomain/__init__.py
+++ b/sphinxcontrib/chapeldomain/__init__.py
@@ -10,7 +10,7 @@
     :license: Apache v2.0, see LICENSE for details.
 
     Chapel website: https://chapel-lang.org/
-    Chapel spec:    https://chapel-lang.org/language.html
+    Chapel spec:    https://chapel-lang.org/docs/language/spec/
 
 """
 

--- a/sphinxcontrib/chapeldomain/__init__.py
+++ b/sphinxcontrib/chapeldomain/__init__.py
@@ -9,8 +9,8 @@
     :copyright: Copyright 2015 by Chapel Team
     :license: Apache v2.0, see LICENSE for details.
 
-    Chapel website: https://chapel.cray.com/
-    Chapel spec:    https://chapel.cray.com/language.html
+    Chapel website: https://chapel-lang.org/
+    Chapel spec:    https://chapel-lang.org/language.html
 
 """
 

--- a/sphinxcontrib/chapeldomain/__init__.py
+++ b/sphinxcontrib/chapeldomain/__init__.py
@@ -9,8 +9,8 @@
     :copyright: Copyright 2015 by Chapel Team
     :license: Apache v2.0, see LICENSE for details.
 
-    Chapel website: http://chapel.cray.com/
-    Chapel spec:    http://chapel.cray.com/language.html
+    Chapel website: https://chapel.cray.com/
+    Chapel spec:    https://chapel.cray.com/language.html
 
 """
 


### PR DESCRIPTION
Includes:
- Update uses of chapel.cray.com to chapel-lang.org
  - Updated spec link `https://chapel-lang.org/language.html` to `https://chapel-lang.org/docs/language/spec/`
- Update all HTTP links to HTTPS, except for those in and referring to the Apache License 2.0 to keep its original text intact. Affected links to domains: chapel-lang.org, sphinx-doc.org, docs.python.org

[reviewed by @bradcray , thanks!]